### PR TITLE
feat: AV1 encoder support, codec discovery improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,8 +63,8 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.38.0+1.3.296"
-source = "git+https://github.com/ash-rs/ash?branch=master#c9292cf1b3fb70e4416fe9c47d6d938bd80d52b4"
+version = "0.38.0+1.4.329"
+source = "git+https://github.com/ash-rs/ash?rev=55dd56906bbb5760e9e9e6c56f45be67f67e0649#55dd56906bbb5760e9e9e6c56f45be67f67e0649"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 dmabuf = []
 
 [dependencies]
-ash = { git = "https://github.com/ash-rs/ash", branch = "master", features = ["loaded"] }
+ash = { git = "https://github.com/ash-rs/ash", rev = "55dd56906bbb5760e9e9e6c56f45be67f67e0649", features = ["loaded"] }
 thiserror = "1.0"
 tracing = "0.1"
 shaderc = "0.8"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # PixelForge
 
-A Vulkan-based video encoding library for Rust, supporting H.264 and H.265 codecs.
+A Vulkan-based video encoding library for Rust, supporting H.264, H.265, and AV1 codecs.
 
 > ⚠️ **Disclaimer**: This library was developed using AI ("vibe-coding") - partly to
 > see if it could be done, partly because I have practically zero experience with Vulkan.
@@ -14,7 +14,7 @@ A Vulkan-based video encoding library for Rust, supporting H.264 and H.265 codec
 ## Features
 
 - **Hardware-accelerated** video encoding using Vulkan Video extensions.
-- **Multiple codec support**: H.264/AVC, H.265/HEVC.
+- **Multiple codec support**: H.264/AVC, H.265/HEVC, AV1.
 - **GPU-native API**: Encode directly from Vulkan images (`vk::Image`).
 - **Flexible configuration**: Rate control (CBR, VBR, CQP), quality levels, GOP settings.
 - **Utility helpers**: [`InputImage`] for easy YUV data upload to GPU.
@@ -28,6 +28,7 @@ A Vulkan-based video encoding library for Rust, supporting H.264 and H.265 codec
 |-------|--------|
 | H.264/AVC | ✓ |
 | H.265/HEVC | ✓ |
+| AV1 | ✓ |
 
 ## Requirements
 
@@ -67,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .app_name("My App")
         .build()?;
 
-    for codec in [Codec::H264, Codec::H265] {
+    for codec in [Codec::H264, Codec::H265, Codec::AV1] {
         println!("{:?}: encode={}",
             codec,
             context.supports_encode(codec)
@@ -136,7 +137,6 @@ cargo run --example encode_h265
 
 1. [] Decoding.
 1. [] B-frames support.
-1. [] AV1 support (depends on a new version of ash with more up-to-date Vulkan support).
 
 ## Contributing
 

--- a/examples/encode_av1.rs
+++ b/examples/encode_av1.rs
@@ -1,0 +1,126 @@
+//! Example: AV1 Video Encoding
+//!
+//! Demonstrates AV1 video encoding using PixelForge with Vulkan Video.
+//! Loads raw YUV420 frames from `testdata/test_frames.yuv`.
+
+use pixelforge::{
+    Codec, EncodeBitDepth, EncodeConfig, Encoder, InputImage, PixelFormat, RateControlMode,
+    VideoContextBuilder,
+};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
+
+const TEST_FRAMES_PATH: &str = "testdata/test_frames.yuv";
+const WIDTH: u32 = 320;
+const HEIGHT: u32 = 240;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing.
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_filter(tracing_subscriber::filter::LevelFilter::INFO),
+        )
+        .init();
+
+    println!("PixelForge AV1 Encode Example\n");
+
+    // Load test frames.
+    let test_path = Path::new(TEST_FRAMES_PATH);
+    if !test_path.exists() {
+        eprintln!("Test frames not found at '{TEST_FRAMES_PATH}'");
+        eprintln!("Generate with: ffmpeg -f lavfi -i testsrc=duration=0.5:size=320x240:rate=30 -pix_fmt yuv420p -f rawvideo testdata/test_frames.yuv");
+        return Ok(());
+    }
+
+    let mut yuv_data = Vec::new();
+    File::open(test_path)?.read_to_end(&mut yuv_data)?;
+
+    let frame_size = (WIDTH * HEIGHT * 3 / 2) as usize;
+    let num_frames = yuv_data.len() / frame_size;
+    println!(
+        "Input: {num_frames} frames, {WIDTH}x{HEIGHT} YUV420, {} bytes",
+        yuv_data.len()
+    );
+
+    // Create video context.
+    let context = VideoContextBuilder::new()
+        .app_name("AV1 Encode Example")
+        .enable_validation(cfg!(debug_assertions))
+        .require_encode(Codec::AV1)
+        .build()?;
+
+    if !context.supports_encode(Codec::AV1) {
+        eprintln!("AV1 encode not supported");
+        return Ok(());
+    }
+
+    // Configure encoder.
+    let config = EncodeConfig::av1(WIDTH, HEIGHT)
+        .with_rate_control(RateControlMode::Cqp)
+        .with_quality_level(26)
+        .with_frame_rate(30, 1)
+        .with_gop_size(30)
+        .with_b_frames(0);
+
+    println!(
+        "Config: {:?}, QP={}, GOP={}, B-frames={}\n",
+        config.rate_control_mode, config.quality_level, config.gop_size, config.b_frame_count
+    );
+
+    // Create input image for uploading frames.
+    let mut input_image = InputImage::new(
+        context.clone(),
+        Codec::AV1,
+        WIDTH,
+        HEIGHT,
+        EncodeBitDepth::Eight,
+        PixelFormat::Yuv420,
+    )?;
+    let mut encoder = Encoder::new(context, config)?;
+    let mut output = File::create("output.av1")?;
+    let mut total_bytes = 0;
+
+    // Encode frames.
+    for i in 0..num_frames {
+        let frame = &yuv_data[i * frame_size..(i + 1) * frame_size];
+
+        // Upload YUV420 data to the input image.
+        input_image.upload_yuv420(frame)?;
+
+        // Encode the image.
+        for packet in encoder.encode(input_image.image())? {
+            total_bytes += packet.data.len();
+            output.write_all(&packet.data)?;
+            println!(
+                "  pts={:<2} dts={:<2}: {:>5} bytes, {:?}{}",
+                packet.pts,
+                packet.dts,
+                packet.data.len(),
+                packet.frame_type,
+                if packet.is_key_frame { " [KEY]" } else { "" }
+            );
+        }
+    }
+
+    // Flush remaining frames.
+    for packet in encoder.flush()? {
+        total_bytes += packet.data.len();
+        output.write_all(&packet.data)?;
+        println!(
+            "  pts={:<2} dts={:<2}: {:>5} bytes, {:?} (flushed)",
+            packet.pts,
+            packet.dts,
+            packet.data.len(),
+            packet.frame_type
+        );
+    }
+
+    let ratio = (num_frames * frame_size) as f64 / total_bytes as f64;
+    println!("\nEncoded {num_frames} frames, {total_bytes} bytes, {ratio:.1}:1 compression");
+    println!("Output: output.av1");
+
+    Ok(())
+}

--- a/examples/query_capabilities.rs
+++ b/examples/query_capabilities.rs
@@ -5,7 +5,6 @@
 
 use ash::vk;
 use pixelforge::{Codec, VideoContextBuilder};
-use std::ffi::CStr;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("PixelForge Codec Capabilities Example");

--- a/examples/verify_all.rs
+++ b/examples/verify_all.rs
@@ -1,6 +1,6 @@
 //! Example: Verify all encoding combinations
 //!
-//! Verifies H.264/H.265, 8-bit/10-bit, YUV420/YUV444 combinations.
+//! Verifies H.264/H.265/AV1, 8-bit/10-bit, YUV420/YUV444 combinations.
 //! Runs PSNR analysis for each combination.
 
 use pixelforge::{
@@ -39,6 +39,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         (Codec::H265, EncodeBitDepth::Eight, PixelFormat::Yuv444),
         (Codec::H265, EncodeBitDepth::Ten, PixelFormat::Yuv420),
         (Codec::H265, EncodeBitDepth::Ten, PixelFormat::Yuv444),
+        (Codec::AV1, EncodeBitDepth::Eight, PixelFormat::Yuv420),
+        (Codec::AV1, EncodeBitDepth::Eight, PixelFormat::Yuv444),
+        (Codec::AV1, EncodeBitDepth::Ten, PixelFormat::Yuv420),
+        (Codec::AV1, EncodeBitDepth::Ten, PixelFormat::Yuv444),
     ];
 
     let context = VideoContextBuilder::new()
@@ -109,7 +113,7 @@ fn run_test(
         let config = match codec {
             Codec::H264 => EncodeConfig::h264(WIDTH, HEIGHT),
             Codec::H265 => EncodeConfig::h265(WIDTH, HEIGHT),
-            _ => return Err("Unsupported codec".into()),
+            Codec::AV1 => EncodeConfig::av1(WIDTH, HEIGHT),
         }
         .with_rate_control(RateControlMode::Cqp)
         .with_quality_level(10)

--- a/src/encoder/av1/api.rs
+++ b/src/encoder/av1/api.rs
@@ -1,0 +1,199 @@
+use super::AV1Encoder;
+
+use crate::encoder::gop::{GopFrameType, GopPosition};
+use crate::encoder::EncodedPacket;
+use crate::error::{PixelForgeError, Result};
+use ash::vk;
+use tracing::debug;
+
+impl AV1Encoder {
+    /// Get the internal input image.
+    ///
+    /// This image can be used as a target for `ColorConverter::convert` to avoid
+    /// an intermediate copy.
+    pub fn input_image(&self) -> vk::Image {
+        self.input_image
+    }
+
+    /// Encode a frame from a GPU image.
+    ///
+    /// This accepts a source image on the GPU and encodes it directly without
+    /// any CPU-side data copies. The source image must be in the correct format
+    /// with the same dimensions as the encoder configuration, and should be in GENERAL layout.
+    ///
+    /// # Panics
+    ///
+    /// The encoder will panic at creation time if B-frames are enabled (b_frame_count > 0),
+    /// as B-frame encoding is not yet supported.
+    pub fn encode(&mut self, src_image: vk::Image) -> Result<Vec<EncodedPacket>> {
+        let gop_position = self.gop.get_next_frame();
+        let display_order = self.input_frame_num;
+        self.input_frame_num += 1;
+
+        debug!(
+            "AV1 encode: frame {} from GPU image, type={:?}",
+            display_order, gop_position.frame_type
+        );
+
+        // Upload from GPU image.
+        self.upload_from_image(src_image)?;
+
+        // Encode immediately.
+        let packet = self.encode_current_frame(&gop_position, display_order)?;
+
+        Ok(vec![packet])
+    }
+
+    /// Internal method to encode the current frame already uploaded to input_image.
+    fn encode_current_frame(
+        &mut self,
+        gop_position: &GopPosition,
+        display_order: u64,
+    ) -> Result<EncodedPacket> {
+        let is_key_frame =
+            gop_position.frame_type.is_idr() || gop_position.frame_type == GopFrameType::I;
+        let is_reference = gop_position.is_reference;
+        let frame_type = match gop_position.frame_type {
+            GopFrameType::Idr | GopFrameType::I => crate::encoder::FrameType::I,
+            GopFrameType::P => crate::encoder::FrameType::P,
+            GopFrameType::B => crate::encoder::FrameType::B,
+        };
+
+        debug!(
+            "Encoding frame: display_order={}, type={:?}, key={}, ref={}",
+            display_order, frame_type, is_key_frame, is_reference
+        );
+
+        if is_key_frame {
+            self.frame_num = 0;
+            self.order_hint = 0;
+            // Reset references for key frames.
+            self.references.clear();
+        }
+
+        let mut encoded_data = Vec::new();
+
+        // For key frames, prepend the AV1 Sequence Header OBU.
+        // This is required for AV1 decoders to initialize (equivalent to H.265 VPS/SPS/PPS).
+        if is_key_frame {
+            if self.header_data.is_none() {
+                let header = self.get_av1_sequence_header()?;
+                debug!(
+                    "AV1 sequence header ({} bytes): {:02X?}",
+                    header.len(),
+                    &header[..std::cmp::min(32, header.len())]
+                );
+                self.header_data = Some(header);
+            }
+            if let Some(ref header) = self.header_data {
+                encoded_data.extend_from_slice(header);
+            }
+        }
+
+        encoded_data.extend_from_slice(&self.encode_frame_internal(gop_position, is_key_frame)?);
+
+        // Save the order_hint used during encoding BEFORE incrementing.
+        let encoded_order_hint = self.order_hint;
+        self.encode_frame_num += 1;
+        self.frame_num += 1;
+        self.order_hint = (self.order_hint + 1) & 0xFF; // 8-bit order hint
+
+        if is_reference {
+            // Update reference tracking for the next frame.
+            // Use the order_hint value that was active during encoding, not the incremented value.
+            let ref_info = super::ReferenceInfo {
+                dpb_slot: self.current_dpb_slot,
+                order_hint: encoded_order_hint,
+            };
+            self.references.insert(0, ref_info);
+            // Limit to negotiated max active references
+            while self.references.len() > self.active_reference_count as usize {
+                self.references.pop();
+            }
+
+            // Find a free DPB slot for the next frame.
+            let used_slots: Vec<u8> = self.references.iter().map(|r| r.dpb_slot).collect();
+            for i in 0..self.dpb_slot_count as u8 {
+                if !used_slots.contains(&i) {
+                    self.current_dpb_slot = i;
+                    break;
+                }
+            }
+        }
+
+        Ok(EncodedPacket {
+            data: encoded_data,
+            frame_type,
+            is_key_frame,
+            pts: display_order,
+            dts: self.encode_frame_num - 1,
+        })
+    }
+
+    /// Flush the encoder and get any remaining packets.
+    pub fn flush(&mut self) -> Result<Vec<EncodedPacket>> {
+        // No buffered frames in the current implementation.
+        Ok(Vec::new())
+    }
+
+    /// Request that the next frame be an IDR/key frame.
+    pub fn request_idr(&mut self) {
+        self.gop.request_idr();
+    }
+
+    /// Retrieve encoded AV1 Sequence Header OBU from video session parameters.
+    /// This uses vkGetEncodedVideoSessionParametersKHR to get the OBU data.
+    /// For AV1, no codec-specific pNext extension is needed (unlike H.265 which
+    /// requires VideoEncodeH265SessionParametersGetInfoKHR).
+    fn get_av1_sequence_header(&self) -> Result<Vec<u8>> {
+        let get_info = vk::VideoEncodeSessionParametersGetInfoKHR {
+            video_session_parameters: self.session_params,
+            ..Default::default()
+        };
+
+        let mut data = vec![0u8; 4096];
+        let mut data_size: usize = data.len();
+        let mut feedback = vk::VideoEncodeSessionParametersFeedbackInfoKHR::default();
+
+        let mut attempts = 0;
+        loop {
+            attempts += 1;
+            let result = unsafe {
+                (self
+                    .video_encode_fn
+                    .fp()
+                    .get_encoded_video_session_parameters_khr)(
+                    self.context.device().handle(),
+                    &get_info,
+                    &mut feedback,
+                    &mut data_size,
+                    data.as_mut_ptr() as *mut std::ffi::c_void,
+                )
+            };
+
+            match result {
+                vk::Result::SUCCESS => {
+                    if data_size == 0 {
+                        return Err(PixelForgeError::SessionParametersCreation(
+                            "AV1 sequence header size is 0".to_string(),
+                        ));
+                    }
+                    data.truncate(data_size);
+                    debug!("Retrieved AV1 sequence header: {} bytes", data.len());
+                    return Ok(data);
+                }
+                vk::Result::INCOMPLETE if attempts < 3 => {
+                    let new_size = data_size.max(data.len() * 2).max(1);
+                    data.resize(new_size, 0);
+                    data_size = data.len();
+                }
+                err => {
+                    return Err(PixelForgeError::SessionParametersCreation(format!(
+                        "Failed to get AV1 sequence header: {:?}",
+                        err
+                    )));
+                }
+            }
+        }
+    }
+}

--- a/src/encoder/av1/encode.rs
+++ b/src/encoder/av1/encode.rs
@@ -280,7 +280,9 @@ impl AV1Encoder {
                 let ref_idx = [ref_info.dpb_slot as i8; 7];
                 let mut order_hints = [0u8; 8];
                 order_hints[ref_info.dpb_slot as usize] = ref_info.order_hint as u8;
-                (ref_idx, order_hints, ref_info.dpb_slot)
+                // primary_ref_frame is a reference NAME index (0=LAST_FRAME), not a DPB slot.
+                // We use SINGLE_REFERENCE with LAST_FRAME, so always 0.
+                (ref_idx, order_hints, 0u8)
             } else {
                 ([0i8; 7], [0u8; 8], 7u8) // 7 = PRIMARY_REF_NONE for key frames
             };

--- a/src/encoder/av1/encode.rs
+++ b/src/encoder/av1/encode.rs
@@ -1,0 +1,577 @@
+use super::{AV1Encoder, MIN_BITSTREAM_BUFFER_SIZE};
+
+use crate::encoder::gop::GopPosition;
+use crate::error::{PixelForgeError, Result};
+use ash::vk;
+use tracing::debug;
+
+impl AV1Encoder {
+    pub(super) fn encode_frame_internal(
+        &mut self,
+        gop_position: &GopPosition,
+        is_key_frame: bool,
+    ) -> Result<Vec<u8>> {
+        let is_reference = gop_position.is_reference;
+
+        debug!(
+            "encode_frame_internal: key={}, ref={}, refs_len={}, dpb_slot={}",
+            is_key_frame,
+            is_reference,
+            self.references.len(),
+            self.current_dpb_slot
+        );
+
+        // Rate control setup.
+        let (rc_mode, average_bitrate, max_bitrate, _qp) = match self.config.rate_control_mode {
+            crate::encoder::RateControlMode::Cqp | crate::encoder::RateControlMode::Disabled => (
+                vk::VideoEncodeRateControlModeFlagsKHR::VBR,
+                100_000_000, // 100 Mbps
+                100_000_000,
+                self.config.quality_level as i32,
+            ),
+            crate::encoder::RateControlMode::Cbr => (
+                vk::VideoEncodeRateControlModeFlagsKHR::CBR,
+                self.config.target_bitrate,
+                self.config.target_bitrate,
+                128, // Default QP for AV1 to adjust from
+            ),
+            crate::encoder::RateControlMode::Vbr => (
+                vk::VideoEncodeRateControlModeFlagsKHR::VBR,
+                self.config.target_bitrate,
+                self.config.max_bitrate,
+                128, // Default QP for AV1 to adjust from
+            ),
+        };
+
+        // Reset command buffer.
+        unsafe {
+            self.context.device().reset_command_buffer(
+                self.encode_command_buffer,
+                vk::CommandBufferResetFlags::empty(),
+            )
+        }
+        .map_err(|e| PixelForgeError::CommandBuffer(e.to_string()))?;
+
+        // Begin command buffer.
+        let begin_info = vk::CommandBufferBeginInfo::default()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+
+        unsafe {
+            self.context
+                .device()
+                .begin_command_buffer(self.encode_command_buffer, &begin_info)
+        }
+        .map_err(|e| PixelForgeError::CommandBuffer(e.to_string()))?;
+
+        // Reset query pool (1 query for bitstream feedback).
+        unsafe {
+            self.context.device().cmd_reset_query_pool(
+                self.encode_command_buffer,
+                self.query_pool,
+                0,
+                1,
+            );
+        }
+
+        // Transition DPB image to video encode DPB layout.
+        let dpb_barrier = vk::ImageMemoryBarrier::default()
+            .old_layout(vk::ImageLayout::UNDEFINED)
+            .new_layout(vk::ImageLayout::VIDEO_ENCODE_DPB_KHR)
+            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .image(self.dpb_images[self.current_dpb_slot as usize])
+            .subresource_range(vk::ImageSubresourceRange {
+                aspect_mask: vk::ImageAspectFlags::COLOR,
+                base_mip_level: 0,
+                level_count: 1,
+                base_array_layer: 0,
+                layer_count: 1,
+            })
+            .src_access_mask(vk::AccessFlags::empty())
+            .dst_access_mask(vk::AccessFlags::empty());
+
+        unsafe {
+            self.context.device().cmd_pipeline_barrier(
+                self.encode_command_buffer,
+                vk::PipelineStageFlags::TOP_OF_PIPE,
+                vk::PipelineStageFlags::BOTTOM_OF_PIPE,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                &[dpb_barrier],
+            );
+        }
+
+        // AV1 frame type.
+        let frame_type = if is_key_frame {
+            ash::vk::native::StdVideoAV1FrameType_STD_VIDEO_AV1_FRAME_TYPE_KEY
+        } else {
+            ash::vk::native::StdVideoAV1FrameType_STD_VIDEO_AV1_FRAME_TYPE_INTER
+        };
+
+        // Build picture info flags using ash's accessor methods.
+        // show_frame must be set for all frames; error_resilient_mode for key frames (match FFmpeg).
+        let mut picture_info_flags = ash::vk::native::StdVideoEncodeAV1PictureInfoFlags {
+            _bitfield_align_1: [],
+            _bitfield_1: Default::default(),
+        };
+        picture_info_flags.set_show_frame(1);
+        if is_key_frame {
+            picture_info_flags.set_error_resilient_mode(1);
+        }
+
+        // Frame extent uses display dimensions (not superblock-aligned coded extent).
+        // The video session's max_coded_extent is the upper bound; individual frames
+        // use actual dimensions so the decoder doesn't show a green border.
+        let frame_extent = vk::Extent2D {
+            width: self.config.dimensions.width,
+            height: self.config.dimensions.height,
+        };
+
+        // Setup reconstructed picture (DPB slot for output).
+        let setup_picture_resource = vk::VideoPictureResourceInfoKHR::default()
+            .coded_offset(vk::Offset2D { x: 0, y: 0 })
+            .coded_extent(frame_extent)
+            .base_array_layer(0)
+            .image_view_binding(self.dpb_image_views[self.current_dpb_slot as usize]);
+        // AV1 reference info for the setup slot.
+        let reference_info_flags = ash::vk::native::StdVideoEncodeAV1ReferenceInfoFlags {
+            _bitfield_align_1: [],
+            _bitfield_1: ash::vk::native::StdVideoEncodeAV1ReferenceInfoFlags::new_bitfield_1(
+                0, 0, 0,
+            ),
+        };
+
+        let std_reference_info = ash::vk::native::StdVideoEncodeAV1ReferenceInfo {
+            flags: reference_info_flags,
+            frame_type: if is_key_frame {
+                ash::vk::native::StdVideoAV1FrameType_STD_VIDEO_AV1_FRAME_TYPE_KEY
+            } else {
+                ash::vk::native::StdVideoAV1FrameType_STD_VIDEO_AV1_FRAME_TYPE_INTER
+            },
+            RefFrameId: self.current_dpb_slot as u32,
+            OrderHint: self.order_hint as u8,
+            reserved1: [0; 3],
+            pExtensionHeader: std::ptr::null(),
+        };
+
+        // AV1 DPB slot info for the setup reference slot (the slot being written).
+        let setup_av1_dpb_info =
+            vk::VideoEncodeAV1DpbSlotInfoKHR::default().std_reference_info(&std_reference_info);
+
+        let mut setup_reference_slot = vk::VideoReferenceSlotInfoKHR::default()
+            .slot_index(self.current_dpb_slot as i32)
+            .picture_resource(&setup_picture_resource);
+
+        // Attach AV1 DPB info to setup slot's pNext chain.
+        setup_reference_slot.p_next =
+            (&setup_av1_dpb_info as *const vk::VideoEncodeAV1DpbSlotInfoKHR).cast();
+
+        // Reference frames for inter frames.
+        let mut reference_slots = Vec::new();
+        let mut av1_reference_infos = Vec::new();
+        let mut ref_picture_resources = Vec::new();
+        let mut ref_std_infos = Vec::new(); // Store std info to keep it alive
+
+        if !is_key_frame && !self.references.is_empty() {
+            // Use the most recent reference frame.
+            let ref_info = &self.references[0];
+
+            // Create StdVideoEncodeAV1ReferenceInfo for the reference slot.
+            let ref_std_info = ash::vk::native::StdVideoEncodeAV1ReferenceInfo {
+                flags: reference_info_flags,
+                frame_type: ash::vk::native::StdVideoAV1FrameType_STD_VIDEO_AV1_FRAME_TYPE_INTER,
+                RefFrameId: ref_info.dpb_slot as u32,
+                OrderHint: ref_info.order_hint as u8,
+                reserved1: [0; 3],
+                pExtensionHeader: std::ptr::null(),
+            };
+            ref_std_infos.push(ref_std_info);
+
+            // Create AV1 DPB slot info for the reference (without pointer first).
+            let av1_ref_info = vk::VideoEncodeAV1DpbSlotInfoKHR::default();
+            av1_reference_infos.push(av1_ref_info);
+            // Now set the pointer after it's in the vector at its final location.
+            av1_reference_infos[0] = av1_reference_infos[0].std_reference_info(&ref_std_infos[0]);
+
+            let ref_picture_resource = vk::VideoPictureResourceInfoKHR::default()
+                .coded_offset(vk::Offset2D { x: 0, y: 0 })
+                .coded_extent(frame_extent)
+                .base_array_layer(0)
+                .image_view_binding(self.dpb_image_views[ref_info.dpb_slot as usize]);
+            ref_picture_resources.push(ref_picture_resource);
+
+            // Create reference slot (without pNext first).
+            let ref_slot = vk::VideoReferenceSlotInfoKHR::default()
+                .slot_index(ref_info.dpb_slot as i32)
+                .picture_resource(&ref_picture_resources[0]);
+            reference_slots.push(ref_slot);
+            // Now set pNext after it's in the vector at its final location.
+            reference_slots[0].p_next =
+                (&av1_reference_infos[0] as *const vk::VideoEncodeAV1DpbSlotInfoKHR).cast();
+        }
+
+        // AV1 quantization parameters - required structure.
+        // Start with a moderate QP that the rate controller can adjust.
+        let quantization_flags = ash::vk::native::StdVideoAV1QuantizationFlags {
+            _bitfield_align_1: [],
+            _bitfield_1: ash::vk::native::StdVideoAV1QuantizationFlags::new_bitfield_1(
+                0, // using_qmatrix
+                0, // diff_uv_delta
+                0, // reserved
+            ),
+        };
+
+        let quantization = ash::vk::native::StdVideoAV1Quantization {
+            flags: quantization_flags,
+            base_q_idx: 128, // Moderate QP (0-255 range)
+            DeltaQYDc: 0,
+            DeltaQUDc: 0,
+            DeltaQUAc: 0,
+            DeltaQVDc: 0,
+            DeltaQVAc: 0,
+            qm_y: 0,
+            qm_u: 0,
+            qm_v: 0,
+        };
+
+        // CDEF (Constrained Directional Enhancement Filter) - required since we enabled it in sequence header.
+        // Match FFmpeg's default initialization (all zeros).
+        let cdef = ash::vk::native::StdVideoAV1CDEF {
+            cdef_damping_minus_3: 0,                       // Match FFmpeg: damping = 3
+            cdef_bits: 0,                                  // 1 CDEF strength combination (2^0)
+            cdef_y_pri_strength: [0, 0, 0, 0, 0, 0, 0, 0], // Match FFmpeg: all zeros
+            cdef_y_sec_strength: [0, 0, 0, 0, 0, 0, 0, 0],
+            cdef_uv_pri_strength: [0, 0, 0, 0, 0, 0, 0, 0],
+            cdef_uv_sec_strength: [0, 0, 0, 0, 0, 0, 0, 0],
+        };
+
+        // Loop filter - deblocking filter parameters.
+        // Match FFmpeg's default initialization.
+        let loop_filter_flags = ash::vk::native::StdVideoAV1LoopFilterFlags {
+            _bitfield_align_1: [],
+            _bitfield_1: ash::vk::native::StdVideoAV1LoopFilterFlags::new_bitfield_1(
+                0, // loop_filter_delta_enabled
+                0, // loop_filter_delta_update
+                0, // reserved
+            ),
+        };
+
+        let loop_filter = ash::vk::native::StdVideoAV1LoopFilter {
+            flags: loop_filter_flags,
+            loop_filter_level: [0, 0, 0, 0], // Match FFmpeg: disable filter initially
+            loop_filter_sharpness: 0,
+            update_ref_delta: 0,
+            // Match FFmpeg's default_loop_filter_ref_deltas: { 1, 0, 0, 0, -1, 0, -1, -1 }
+            loop_filter_ref_deltas: [1, 0, 0, 0, -1, 0, -1, -1],
+            update_mode_delta: 1, // Match FFmpeg: set to 1
+            loop_filter_mode_deltas: [0; 2],
+        };
+
+        // Tile info - FFmpeg has this commented out with "TODO FIX" at line 340.
+        // Match FFmpeg: don't provide tile info (set to null).
+        // Note: If this causes issues, we may need to re-enable it with proper values.
+
+        // Build ref_frame_idx, ref_order_hint, and primary_ref_frame based on frame type.
+        // Match FFmpeg: for P frames all 7 ref_frame_idx entries point to same reference slot.
+        let (ref_frame_idx, ref_order_hint, primary_ref_frame) =
+            if !is_key_frame && !self.references.is_empty() {
+                let ref_info = &self.references[0];
+                let ref_idx = [ref_info.dpb_slot as i8; 7];
+                let mut order_hints = [0u8; 8];
+                order_hints[ref_info.dpb_slot as usize] = ref_info.order_hint as u8;
+                (ref_idx, order_hints, ref_info.dpb_slot)
+            } else {
+                ([0i8; 7], [0u8; 8], 7u8) // 7 = PRIMARY_REF_NONE for key frames
+            };
+
+        // refresh_frame_flags: key frames refresh ALL slots, P frames refresh current slot.
+        let refresh_frame_flags = if is_key_frame {
+            0xFF // Key frames refresh all 8 reference slots (match FFmpeg)
+        } else if is_reference {
+            1u8 << self.current_dpb_slot // P frames refresh current slot
+        } else {
+            0x00 // Non-reference frames don't refresh
+        };
+
+        // AV1 encode picture info.
+        let std_picture_info = ash::vk::native::StdVideoEncodeAV1PictureInfo {
+            flags: picture_info_flags,
+            frame_type,
+            frame_presentation_time: self.frame_num,
+            current_frame_id: self.current_dpb_slot as u32, // Match FFmpeg: slot index
+            order_hint: self.order_hint as u8,
+            primary_ref_frame,
+            refresh_frame_flags,
+            coded_denom: 0,
+            render_width_minus_1: (self.config.dimensions.width - 1) as u16,
+            render_height_minus_1: (self.config.dimensions.height - 1) as u16,
+            interpolation_filter: ash::vk::native::StdVideoAV1InterpolationFilter_STD_VIDEO_AV1_INTERPOLATION_FILTER_EIGHTTAP,
+            TxMode: ash::vk::native::StdVideoAV1TxMode_STD_VIDEO_AV1_TX_MODE_SELECT,
+            delta_q_res: 0,
+            delta_lf_res: 0,
+            ref_order_hint,
+            ref_frame_idx,
+            reserved1: [0; 3],
+            delta_frame_id_minus_1: [0; 7],
+            pTileInfo: std::ptr::null(), // Match FFmpeg: null (not implemented)
+            pQuantization: &quantization,
+            pSegmentation: std::ptr::null(),
+            pLoopFilter: &loop_filter,
+            pCDEF: &cdef,
+            pLoopRestoration: std::ptr::null(),
+            pGlobalMotion: std::ptr::null(),
+            pExtensionHeader: std::ptr::null(),
+            pBufferRemovalTimes: std::ptr::null(),
+        };
+
+        // Reference name slot indices - maps AV1 reference frame names to DPB slot indices.
+        // For SINGLE_REFERENCE mode, we use LAST_FRAME (index 0).
+        let mut reference_name_slot_indices = [-1i32; 7];
+
+        // For inter frames, map LAST_FRAME to our reference DPB slot.
+        if !is_key_frame && !self.references.is_empty() {
+            let ref_info = &self.references[0];
+            reference_name_slot_indices[0] = ref_info.dpb_slot as i32;
+        }
+
+        // Set prediction mode and rate control group based on frame type.
+        let (prediction_mode, rate_control_group) = if is_key_frame {
+            (
+                vk::VideoEncodeAV1PredictionModeKHR::INTRA_ONLY,
+                vk::VideoEncodeAV1RateControlGroupKHR::INTRA,
+            )
+        } else {
+            (
+                vk::VideoEncodeAV1PredictionModeKHR::SINGLE_REFERENCE,
+                vk::VideoEncodeAV1RateControlGroupKHR::PREDICTIVE,
+            )
+        };
+
+        let av1_picture_info = vk::VideoEncodeAV1PictureInfoKHR::default()
+            .std_picture_info(&std_picture_info)
+            .prediction_mode(prediction_mode)
+            .rate_control_group(rate_control_group)
+            .reference_name_slot_indices(reference_name_slot_indices);
+
+        // Rate control layer info.
+        let rc_layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
+            .average_bitrate(average_bitrate as u64)
+            .max_bitrate(max_bitrate as u64)
+            .frame_rate_numerator(self.config.frame_rate_numerator)
+            .frame_rate_denominator(self.config.frame_rate_denominator);
+
+        // Rate control info.
+        let rc_info = vk::VideoEncodeRateControlInfoKHR::default()
+            .rate_control_mode(rc_mode)
+            .virtual_buffer_size_in_ms(1000) // 1 second VBV buffer
+            .layers(std::slice::from_ref(&rc_layer_info));
+
+        // Video begin coding info.
+        // FFmpeg trick: Include the setup slot in reference_slots but with slotIndex = -1.
+        // This binds the picture resource without requiring the slot to be active yet.
+        let mut all_reference_slots = Vec::new();
+
+        if is_reference {
+            // Create a copy of setup_reference_slot with slotIndex = -1
+            let mut setup_slot_for_binding = setup_reference_slot;
+            setup_slot_for_binding.slot_index = -1; // Magic value to bind resource without activation
+            all_reference_slots.push(setup_slot_for_binding);
+        }
+
+        // Add reference slots (already active slots we're reading from)
+        all_reference_slots.extend_from_slice(&reference_slots);
+
+        // Begin video coding with rate control info on first frame only (matching HEVC pattern).
+        let is_first_frame = self.encode_frame_num == 0;
+        let mut begin_coding_info = if is_first_frame {
+            vk::VideoBeginCodingInfoKHR::default()
+                .video_session(self.session)
+                .video_session_parameters(self.session_params)
+        } else {
+            let mut info = vk::VideoBeginCodingInfoKHR::default()
+                .video_session(self.session)
+                .video_session_parameters(self.session_params);
+            info.p_next = (&rc_info as *const vk::VideoEncodeRateControlInfoKHR).cast();
+            info
+        };
+
+        if !all_reference_slots.is_empty() {
+            begin_coding_info = begin_coding_info.reference_slots(&all_reference_slots);
+        }
+
+        unsafe {
+            self.video_queue_fn
+                .cmd_begin_video_coding(self.encode_command_buffer, &begin_coding_info);
+        }
+
+        // Initialize video session on first frame.
+        if is_first_frame {
+            let reset_control_info = vk::VideoCodingControlInfoKHR::default()
+                .flags(vk::VideoCodingControlFlagsKHR::RESET);
+            unsafe {
+                self.video_queue_fn
+                    .cmd_control_video_coding(self.encode_command_buffer, &reset_control_info);
+            }
+
+            // Set rate control after reset (matching HEVC pattern).
+            let mut rate_control = vk::VideoCodingControlInfoKHR::default()
+                .flags(vk::VideoCodingControlFlagsKHR::ENCODE_RATE_CONTROL);
+            rate_control.p_next = (&rc_info as *const vk::VideoEncodeRateControlInfoKHR).cast();
+            unsafe {
+                self.video_queue_fn
+                    .cmd_control_video_coding(self.encode_command_buffer, &rate_control);
+            }
+        }
+
+        // Encode info.
+        let src_picture_resource = vk::VideoPictureResourceInfoKHR::default()
+            .coded_offset(vk::Offset2D { x: 0, y: 0 })
+            .coded_extent(frame_extent)
+            .base_array_layer(0)
+            .image_view_binding(self.input_image_view);
+
+        let mut encode_info = vk::VideoEncodeInfoKHR::default()
+            .src_picture_resource(src_picture_resource)
+            .dst_buffer(self.bitstream_buffer)
+            .dst_buffer_offset(0)
+            .dst_buffer_range(MIN_BITSTREAM_BUFFER_SIZE as u64);
+
+        if is_reference {
+            encode_info = encode_info.setup_reference_slot(&setup_reference_slot);
+        }
+
+        if !reference_slots.is_empty() {
+            encode_info = encode_info.reference_slots(&reference_slots);
+        }
+
+        encode_info.p_next = (&av1_picture_info as *const vk::VideoEncodeAV1PictureInfoKHR).cast();
+
+        // Begin query to capture encode feedback (bitstream size, status).
+        unsafe {
+            self.context.device().cmd_begin_query(
+                self.encode_command_buffer,
+                self.query_pool,
+                0,
+                vk::QueryControlFlags::empty(),
+            );
+        }
+
+        unsafe {
+            self.video_encode_fn
+                .cmd_encode_video(self.encode_command_buffer, &encode_info);
+        }
+
+        // End query.
+        unsafe {
+            self.context
+                .device()
+                .cmd_end_query(self.encode_command_buffer, self.query_pool, 0);
+        }
+
+        // End video coding.
+        let end_coding_info = vk::VideoEndCodingInfoKHR::default();
+        unsafe {
+            self.video_queue_fn
+                .cmd_end_video_coding(self.encode_command_buffer, &end_coding_info);
+        }
+
+        // End command buffer.
+        unsafe {
+            self.context
+                .device()
+                .end_command_buffer(self.encode_command_buffer)
+        }
+        .map_err(|e| PixelForgeError::CommandBuffer(e.to_string()))?;
+
+        // Submit command buffer.
+        let submit_info = vk::SubmitInfo::default()
+            .command_buffers(std::slice::from_ref(&self.encode_command_buffer));
+
+        unsafe { self.context.device().reset_fences(&[self.encode_fence]) }
+            .map_err(|e| PixelForgeError::Synchronization(e.to_string()))?;
+
+        unsafe {
+            self.context.device().queue_submit(
+                self.context
+                    .video_encode_queue()
+                    .expect("Video encode queue should be available"),
+                &[submit_info],
+                self.encode_fence,
+            )
+        }
+        .map_err(|e| PixelForgeError::Synchronization(e.to_string()))?;
+
+        // Wait for encode to complete.
+        unsafe {
+            self.context
+                .device()
+                .wait_for_fences(&[self.encode_fence], true, u64::MAX)
+        }
+        .map_err(|e| PixelForgeError::Synchronization(e.to_string()))?;
+
+        // Get query results for bitstream size.
+        // Need to use raw vkGetQueryPoolResults because ash's wrapper infers query count from buffer size.
+        // We want 1 query returning 12 bytes (3 u32s): offset, bytes_written, status.
+        let mut query_results = [0u32; 3];
+        let result = unsafe {
+            (self.context.device().fp_v1_0().get_query_pool_results)(
+                self.context.device().handle(),
+                self.query_pool,
+                0,  // firstQuery
+                1,  // queryCount (explicit: we want 1 query, not 3!)
+                12, // dataSize in bytes (3 u32s: offset, bytes_written, status)
+                query_results.as_mut_ptr() as *mut std::ffi::c_void,
+                12, // stride (12 bytes per query result)
+                vk::QueryResultFlags::WAIT | vk::QueryResultFlags::WITH_STATUS_KHR,
+            )
+        };
+        if result != vk::Result::SUCCESS {
+            return Err(PixelForgeError::QueryPool(format!(
+                "Failed to get query results: {:?}",
+                result
+            )));
+        }
+
+        // Query result layout (WITH_STATUS at the END per Vulkan spec):
+        //   [0] = bitstream buffer offset (from BITSTREAM_BUFFER_OFFSET feedback flag)
+        //   [1] = bitstream bytes written (from BITSTREAM_BYTES_WRITTEN feedback flag)
+        //   [2] = status (VkQueryResultStatusKHR: 1 = COMPLETE, 0 = NOT_READY, -1 = ERROR)
+        let bitstream_offset = query_results[0];
+        let bitstream_size = query_results[1] as usize;
+        let status = query_results[2] as i32;
+
+        debug!(
+            "AV1 query results: status={}, offset={}, size={}",
+            status, bitstream_offset, bitstream_size
+        );
+
+        if status != 1 {
+            return Err(PixelForgeError::CommandBuffer(format!(
+                "Encode query status indicates failure: {} (1=COMPLETE, 0=NOT_READY, -1=ERROR)",
+                status
+            )));
+        }
+
+        if bitstream_size == 0 || bitstream_size > MIN_BITSTREAM_BUFFER_SIZE {
+            return Err(PixelForgeError::CommandBuffer(format!(
+                "Invalid bitstream size: {}",
+                bitstream_size
+            )));
+        }
+
+        // Copy encoded data from mapped buffer at the reported offset.
+        let mut encoded_data = vec![0u8; bitstream_size];
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                self.bitstream_buffer_ptr.add(bitstream_offset as usize),
+                encoded_data.as_mut_ptr(),
+                bitstream_size,
+            );
+        }
+
+        debug!("Encoded frame: {} bytes", bitstream_size);
+
+        Ok(encoded_data)
+    }
+}

--- a/src/encoder/av1/init.rs
+++ b/src/encoder/av1/init.rs
@@ -44,11 +44,11 @@ impl AV1Encoder {
         let luma_bit_depth: vk::VideoComponentBitDepthFlagsKHR = config.bit_depth.into();
         let chroma_bit_depth: vk::VideoComponentBitDepthFlagsKHR = config.bit_depth.into();
 
-        // AV1 profile: Main profile for 8-bit 4:2:0, High profile for 10-bit or 4:4:4
-        let profile = match (config.bit_depth, config.pixel_format) {
-            (crate::encoder::BitDepth::Eight, PixelFormat::Yuv420) => {
-                ash::vk::native::StdVideoAV1Profile_STD_VIDEO_AV1_PROFILE_MAIN
-            }
+        // AV1 profile selection based on chroma subsampling (not bit depth).
+        // Main profile: 8/10-bit, 4:2:0 only.
+        // High profile: 8/10-bit, 4:2:0 and 4:4:4.
+        let profile = match config.pixel_format {
+            PixelFormat::Yuv420 => ash::vk::native::StdVideoAV1Profile_STD_VIDEO_AV1_PROFILE_MAIN,
             _ => ash::vk::native::StdVideoAV1Profile_STD_VIDEO_AV1_PROFILE_HIGH,
         };
 

--- a/src/encoder/av1/init.rs
+++ b/src/encoder/av1/init.rs
@@ -1,0 +1,525 @@
+use super::{AV1Encoder, MIN_BITSTREAM_BUFFER_SIZE, SUPERBLOCK_SIZE};
+
+use crate::encoder::gop::GopStructure;
+use crate::encoder::resources::{
+    allocate_session_memory, create_bitstream_buffer, create_command_resources, create_dpb_images,
+    create_image, get_video_format, make_codec_name, map_bitstream_buffer,
+    query_supported_video_formats,
+};
+use crate::encoder::PixelFormat;
+use crate::error::{PixelForgeError, Result};
+use crate::vulkan::VideoContext;
+use ash::vk;
+use std::ptr;
+use tracing::{debug, info};
+
+impl AV1Encoder {
+    /// Create a new AV1 encoder.
+    pub fn new(context: VideoContext, config: crate::encoder::EncodeConfig) -> Result<Self> {
+        // B-frames are not yet supported.
+        if config.b_frame_count > 0 {
+            panic!(
+                "B-frame encoding is not yet supported. Set b_frame_count=0 in encoder config. \
+                 Got b_frame_count={}",
+                config.b_frame_count
+            );
+        }
+
+        let width = config.dimensions.width;
+        let height = config.dimensions.height;
+
+        info!(
+            "Creating AV1 encoder: requested {}x{}, pixel_format={:?}",
+            width, height, config.pixel_format
+        );
+
+        // Load video queue extension functions.
+        let video_queue_fn =
+            ash::khr::video_queue::Device::load(context.instance(), context.device());
+        let video_encode_fn =
+            ash::khr::video_encode_queue::Device::load(context.instance(), context.device());
+
+        // Get chroma subsampling from pixel format.
+        let chroma_subsampling: vk::VideoChromaSubsamplingFlagsKHR = config.pixel_format.into();
+        let luma_bit_depth: vk::VideoComponentBitDepthFlagsKHR = config.bit_depth.into();
+        let chroma_bit_depth: vk::VideoComponentBitDepthFlagsKHR = config.bit_depth.into();
+
+        // AV1 profile: Main profile for 8-bit 4:2:0, High profile for 10-bit or 4:4:4
+        let profile = match (config.bit_depth, config.pixel_format) {
+            (crate::encoder::BitDepth::Eight, PixelFormat::Yuv420) => {
+                ash::vk::native::StdVideoAV1Profile_STD_VIDEO_AV1_PROFILE_MAIN
+            }
+            _ => ash::vk::native::StdVideoAV1Profile_STD_VIDEO_AV1_PROFILE_HIGH,
+        };
+
+        // Preferred input format based on pixel format and bit depth.
+        let preferred_src_format = get_video_format(config.pixel_format, config.bit_depth);
+
+        // Create AV1 encode profile.
+        let mut av1_profile_info = vk::VideoEncodeAV1ProfileInfoKHR::default().std_profile(profile);
+
+        let mut profile_info = vk::VideoProfileInfoKHR::default()
+            .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_AV1)
+            .chroma_subsampling(chroma_subsampling)
+            .luma_bit_depth(luma_bit_depth)
+            .chroma_bit_depth(chroma_bit_depth);
+        profile_info.p_next =
+            (&mut av1_profile_info as *mut vk::VideoEncodeAV1ProfileInfoKHR).cast();
+
+        // Query encode capabilities.
+        let video_queue_instance =
+            ash::khr::video_queue::Instance::load(context.entry(), context.instance());
+        let mut av1_capabilities = vk::VideoEncodeAV1CapabilitiesKHR::default();
+        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR {
+            p_next: (&mut av1_capabilities as *mut vk::VideoEncodeAV1CapabilitiesKHR).cast(),
+            ..Default::default()
+        };
+        let mut capabilities = vk::VideoCapabilitiesKHR {
+            p_next: (&mut encode_capabilities as *mut vk::VideoEncodeCapabilitiesKHR).cast(),
+            ..Default::default()
+        };
+
+        let result = unsafe {
+            (video_queue_instance
+                .fp()
+                .get_physical_device_video_capabilities_khr)(
+                context.physical_device(),
+                &profile_info,
+                &mut capabilities,
+            )
+        };
+        if result != vk::Result::SUCCESS {
+            return Err(PixelForgeError::NoSuitableDevice(format!(
+                "Failed to query Vulkan Video encode capabilities for AV1: {:?}",
+                result
+            )));
+        }
+
+        // Helper functions for alignment calculations.
+        let gcd = |mut a: u32, mut b: u32| {
+            while b != 0 {
+                let tmp = a % b;
+                a = b;
+                b = tmp;
+            }
+            a
+        };
+        let lcm = |a: u32, b: u32| {
+            if a == 0 || b == 0 {
+                0
+            } else {
+                a / gcd(a, b) * b
+            }
+        };
+        let align_up = |value: u32, alignment: u32| {
+            if alignment <= 1 {
+                value
+            } else {
+                value.div_ceil(alignment) * alignment
+            }
+        };
+
+        let gran_w = capabilities.picture_access_granularity.width.max(1);
+        let gran_h = capabilities.picture_access_granularity.height.max(1);
+        let align_w = lcm(SUPERBLOCK_SIZE, gran_w);
+        let align_h = lcm(SUPERBLOCK_SIZE, gran_h);
+
+        let mut aligned_width = align_up(width, align_w);
+        let mut aligned_height = align_up(height, align_h);
+
+        aligned_width = aligned_width.max(capabilities.min_coded_extent.width);
+        aligned_height = aligned_height.max(capabilities.min_coded_extent.height);
+
+        if aligned_width > capabilities.max_coded_extent.width
+            || aligned_height > capabilities.max_coded_extent.height
+        {
+            return Err(PixelForgeError::InvalidInput(format!(
+                "Requested coded extent {}x{} (aligned to {}x{}) exceeds device max {}x{}",
+                width,
+                height,
+                aligned_width,
+                aligned_height,
+                capabilities.max_coded_extent.width,
+                capabilities.max_coded_extent.height
+            )));
+        }
+
+        info!(
+            "Using coded extent {}x{} (granularity {}x{})",
+            aligned_width, aligned_height, gran_w, gran_h
+        );
+
+        // Query supported formats.
+        let supported_src_formats = query_supported_video_formats(
+            &context,
+            &profile_info,
+            vk::ImageUsageFlags::VIDEO_ENCODE_SRC_KHR,
+        )?;
+        let supported_dpb_formats = query_supported_video_formats(
+            &context,
+            &profile_info,
+            vk::ImageUsageFlags::VIDEO_ENCODE_DPB_KHR,
+        )?;
+
+        if supported_src_formats.is_empty() {
+            return Err(PixelForgeError::NoSuitableDevice(
+                "No supported Vulkan Video SRC formats for AV1".to_string(),
+            ));
+        }
+        if supported_dpb_formats.is_empty() {
+            return Err(PixelForgeError::NoSuitableDevice(
+                "No supported Vulkan Video DPB formats for AV1".to_string(),
+            ));
+        }
+
+        info!("Supported SRC formats: {:?}", supported_src_formats);
+        info!("Supported DPB formats: {:?}", supported_dpb_formats);
+
+        let picture_format = if supported_src_formats.contains(&preferred_src_format) {
+            preferred_src_format
+        } else {
+            return Err(PixelForgeError::NoSuitableDevice(format!(
+                "Preferred input format {:?} not supported for AV1",
+                preferred_src_format
+            )));
+        };
+
+        let reference_picture_format = supported_dpb_formats
+            .iter()
+            .copied()
+            .find(|f| *f == picture_format)
+            .unwrap_or(supported_dpb_formats[0]);
+
+        debug!(
+            "Selected formats: picture={:?}, reference={:?}",
+            picture_format, reference_picture_format
+        );
+
+        // Get encode queue family.
+        let encode_queue_family = context.video_encode_queue_family().ok_or_else(|| {
+            PixelForgeError::NoSuitableDevice("No video encode queue family available".to_string())
+        })?;
+
+        // Create video session.
+        let std_header_version = vk::ExtensionProperties {
+            extension_name: make_codec_name(b"VK_STD_vulkan_video_codec_av1_encode"),
+            spec_version: vk::make_api_version(0, 1, 0, 0),
+        };
+
+        // Calculate DPB slots and active references.
+        let max_dpb_slots_supported = capabilities.max_dpb_slots as usize;
+        let max_active_reference_pictures_supported =
+            capabilities.max_active_reference_pictures as usize;
+
+        if max_dpb_slots_supported < 2 {
+            return Err(PixelForgeError::NoSuitableDevice(format!(
+                "Device reports max_dpb_slots={}, need at least 2",
+                max_dpb_slots_supported
+            )));
+        }
+
+        let mut target_active_refs = (config.max_reference_frames as usize)
+            .min(max_active_reference_pictures_supported)
+            .min(8); // AV1 supports up to 8 reference frames
+
+        if target_active_refs < 1 && max_active_reference_pictures_supported >= 1 {
+            target_active_refs = 1;
+        }
+
+        // AV1 typically needs: active refs + 1 for current frame being setup
+        let requested_dpb_slots = (target_active_refs + 1).min(max_dpb_slots_supported);
+
+        info!(
+            "DPB configuration: slots={}, active_refs={} (max_supported: slots={}, refs={})",
+            requested_dpb_slots,
+            target_active_refs,
+            max_dpb_slots_supported,
+            max_active_reference_pictures_supported
+        );
+
+        let session_create_info = vk::VideoSessionCreateInfoKHR::default()
+            .queue_family_index(encode_queue_family)
+            .video_profile(&profile_info)
+            .picture_format(picture_format)
+            .max_coded_extent(vk::Extent2D {
+                width: aligned_width,
+                height: aligned_height,
+            })
+            .reference_picture_format(reference_picture_format)
+            .max_dpb_slots(requested_dpb_slots as u32)
+            .max_active_reference_pictures(target_active_refs as u32)
+            .std_header_version(&std_header_version);
+
+        let mut session = vk::VideoSessionKHR::null();
+        let result = unsafe {
+            (video_queue_fn.fp().create_video_session_khr)(
+                context.device().handle(),
+                &session_create_info,
+                ptr::null(),
+                &mut session,
+            )
+        };
+        if result != vk::Result::SUCCESS {
+            return Err(PixelForgeError::VideoSessionCreation(format!(
+                "{:?}",
+                result
+            )));
+        }
+
+        // Allocate session memory.
+        let session_memory = allocate_session_memory(&context, session, &video_queue_fn)?;
+
+        // Create AV1 sequence header - similar to H.265 VPS/SPS/PPS but for AV1.
+        // Calculate frame dimension representation bits.
+        // Use actual display dimensions for sequence header (not coded extent).
+        // The video session's max_coded_extent is the upper bound for alignment,
+        // but the sequence header and per-frame coded extents use display dimensions.
+        let frame_width_bits = 32 - (width - 1).leading_zeros();
+        let frame_height_bits = 32 - (height - 1).leading_zeros();
+
+        // AV1 color configuration.
+        let color_config_flags = ash::vk::native::StdVideoAV1ColorConfigFlags {
+            _bitfield_align_1: [],
+            _bitfield_1: ash::vk::native::StdVideoAV1ColorConfigFlags::new_bitfield_1(
+                0, // mono_chrome
+                1, // color_range (full range)
+                0, // separate_uv_delta_q
+                1, // color_description_present_flag (we provide color primaries/transfer/matrix)
+                0, // reserved
+            ),
+        };
+
+        // Bit depth: 8 for Eight, 10 for Ten
+        let bit_depth = match config.bit_depth {
+            crate::encoder::BitDepth::Eight => 8,
+            crate::encoder::BitDepth::Ten => 10,
+        };
+
+        // Chroma subsampling based on pixel format.
+        let (subsampling_x, subsampling_y) = match config.pixel_format {
+            PixelFormat::Yuv420 => (1u8, 1u8), // 4:2:0
+            PixelFormat::Yuv444 => (0u8, 0u8), // 4:4:4
+            _ => (1u8, 1u8),                   // Default to 4:2:0
+        };
+
+        let color_config = ash::vk::native::StdVideoAV1ColorConfig {
+            flags: color_config_flags,
+            BitDepth: bit_depth,
+            subsampling_x,
+            subsampling_y,
+            reserved1: 0,
+            color_primaries: ash::vk::native::StdVideoAV1ColorPrimaries_STD_VIDEO_AV1_COLOR_PRIMARIES_BT_709,
+            transfer_characteristics: ash::vk::native::StdVideoAV1TransferCharacteristics_STD_VIDEO_AV1_TRANSFER_CHARACTERISTICS_BT_709,
+            matrix_coefficients: ash::vk::native::StdVideoAV1MatrixCoefficients_STD_VIDEO_AV1_MATRIX_COEFFICIENTS_BT_709,
+            chroma_sample_position: ash::vk::native::StdVideoAV1ChromaSamplePosition_STD_VIDEO_AV1_CHROMA_SAMPLE_POSITION_UNKNOWN,
+        };
+
+        // AV1 sequence header flags - use minimal set to avoid driver issues.
+        // Disable features we're not providing data for (restoration, most inter-frame features).
+        let seq_flags = ash::vk::native::StdVideoAV1SequenceHeaderFlags {
+            _bitfield_align_1: [],
+            _bitfield_1: ash::vk::native::StdVideoAV1SequenceHeaderFlags::new_bitfield_1(
+                0, // still_picture
+                0, // reduced_still_picture_header
+                0, // use_128x128_superblock (use 64x64 superblocks)
+                0, // enable_filter_intra - disable for simplicity
+                0, // enable_intra_edge_filter - disable for simplicity
+                0, // enable_interintra_compound
+                0, // enable_masked_compound
+                0, // enable_warped_motion - disable for simplicity
+                0, // enable_dual_filter - disable for simplicity
+                1, // enable_order_hint - keep for reference frames
+                0, // enable_jnt_comp
+                0, // enable_ref_frame_mvs
+                0, // frame_id_numbers_present_flag
+                0, // enable_superres
+                1, // enable_cdef - keep enabled
+                0, // enable_restoration - DISABLE (we don't provide restoration data)
+                0, // film_grain_params_present
+                0, // timing_info_present_flag
+                0, // initial_display_delay_present_flag
+                0, // reserved
+            ),
+        };
+
+        let av1_sequence_header = ash::vk::native::StdVideoAV1SequenceHeader {
+            flags: seq_flags,
+            seq_profile: profile,
+            frame_width_bits_minus_1: (frame_width_bits - 1) as u8,
+            frame_height_bits_minus_1: (frame_height_bits - 1) as u8,
+            max_frame_width_minus_1: (width - 1) as u16,
+            max_frame_height_minus_1: (height - 1) as u16,
+            delta_frame_id_length_minus_2: 0,
+            additional_frame_id_length_minus_1: 0,
+            order_hint_bits_minus_1: 7, // 8 bits for order hint
+            seq_force_integer_mv: 0,
+            seq_force_screen_content_tools: 0,
+            reserved1: [0; 5],
+            pColorConfig: &color_config,
+            pTimingInfo: ptr::null(), // No timing info
+        };
+
+        // Create decoder model info (zero-initialized like FFmpeg).
+        let decoder_model_info = ash::vk::native::StdVideoEncodeAV1DecoderModelInfo {
+            buffer_delay_length_minus_1: 0,
+            buffer_removal_time_length_minus_1: 0,
+            frame_presentation_time_length_minus_1: 0,
+            reserved1: 0,
+            num_units_in_decoding_tick: 0,
+        };
+
+        // Create operating point info (single operating point like FFmpeg).
+        let operating_point = ash::vk::native::StdVideoEncodeAV1OperatingPointInfo {
+            flags: ash::vk::native::StdVideoEncodeAV1OperatingPointInfoFlags {
+                _bitfield_align_1: [],
+                _bitfield_1:
+                    ash::vk::native::StdVideoEncodeAV1OperatingPointInfoFlags::new_bitfield_1(
+                        0, // decoder_model_present_for_this_op
+                        0, // low_delay_mode_flag
+                        0, // initial_display_delay_present_for_this_op
+                        0, // reserved
+                    ),
+            },
+            operating_point_idc: 0,
+            seq_level_idx: 5, // Level 3.1 (encoded as: 2.0=0, 2.1=1, ... 3.0=4, 3.1=5)
+            seq_tier: 0,
+            initial_display_delay_minus_1: 0,
+            decoder_buffer_delay: 0,
+            encoder_buffer_delay: 0,
+        };
+
+        // Create session parameters with all required structures (matching FFmpeg).
+        let mut av1_session_params_create_info =
+            vk::VideoEncodeAV1SessionParametersCreateInfoKHR::default()
+                .std_sequence_header(&av1_sequence_header)
+                .std_decoder_model_info(&decoder_model_info)
+                .std_operating_points(std::slice::from_ref(&operating_point));
+
+        // Add quality level info to pNext chain (matching FFmpeg).
+        // Chain: SessionParametersCreateInfo -> QualityLevelInfo -> AV1SessionParametersCreateInfo
+        let mut quality_info = vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0); // Default quality level
+
+        quality_info.p_next = (&mut av1_session_params_create_info
+            as *mut vk::VideoEncodeAV1SessionParametersCreateInfoKHR)
+            .cast();
+
+        let session_params_create_info = vk::VideoSessionParametersCreateInfoKHR {
+            video_session: session,
+            p_next: (&mut quality_info as *mut vk::VideoEncodeQualityLevelInfoKHR).cast(),
+            ..Default::default()
+        };
+
+        let session_params = unsafe {
+            video_queue_fn
+                .create_video_session_parameters(&session_params_create_info, None)
+                .map_err(|e| {
+                    PixelForgeError::SessionParametersCreation(format!(
+                        "Failed to create AV1 session parameters: {:?}",
+                        e
+                    ))
+                })?
+        };
+
+        // Create input image.
+        let (input_image, input_image_memory, input_image_view) = create_image(
+            &context,
+            aligned_width,
+            aligned_height,
+            picture_format,
+            false, // is_dpb
+            &profile_info,
+        )?;
+
+        let input_image_layout = vk::ImageLayout::UNDEFINED;
+
+        // Create DPB images.
+        let (dpb_images, dpb_image_memories, dpb_image_views) = create_dpb_images(
+            &context,
+            aligned_width,
+            aligned_height,
+            reference_picture_format,
+            requested_dpb_slots,
+            &profile_info,
+        )?;
+
+        // Create bitstream buffer.
+        let bitstream_buffer_size =
+            MIN_BITSTREAM_BUFFER_SIZE.max(aligned_width as usize * aligned_height as usize);
+        let (bitstream_buffer, bitstream_buffer_memory) =
+            create_bitstream_buffer(&context, bitstream_buffer_size, &profile_info)?;
+
+        // Map bitstream buffer persistently.
+        let bitstream_buffer_ptr =
+            map_bitstream_buffer(&context, bitstream_buffer_memory, bitstream_buffer_size)?;
+
+        // Create command resources.
+        let cmd_resources = create_command_resources(&context, encode_queue_family)?;
+        let command_pool = cmd_resources.command_pool;
+        let upload_command_buffer = cmd_resources.upload_command_buffer;
+        let upload_fence = cmd_resources.upload_fence;
+        let encode_command_buffer = cmd_resources.encode_command_buffer;
+        let encode_fence = cmd_resources.encode_fence;
+
+        // Create query pool for bitstream size queries.
+        // Need 1 query to capture bitstream offset and size.
+        // Need to provide profile info and feedback flags in pNext chain.
+        let mut query_feedback_info = vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR::default()
+            .encode_feedback_flags(
+                vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET
+                    | vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN,
+            );
+        query_feedback_info.p_next = (&profile_info as *const vk::VideoProfileInfoKHR).cast();
+
+        let mut query_pool_create_info = vk::QueryPoolCreateInfo::default()
+            .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
+            .query_count(1);
+        query_pool_create_info.p_next =
+            (&query_feedback_info as *const vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR).cast();
+
+        let query_pool = unsafe {
+            context
+                .device()
+                .create_query_pool(&query_pool_create_info, None)
+                .map_err(|e| PixelForgeError::QueryPool(e.to_string()))?
+        };
+
+        // Initialize GOP structure.
+        let gop = GopStructure::new(config.gop_size, config.b_frame_count, config.gop_size);
+
+        Ok(Self {
+            context,
+            config,
+            gop,
+            video_queue_fn,
+            video_encode_fn,
+            session,
+            session_params,
+            session_memory,
+            input_frame_num: 0,
+            encode_frame_num: 0,
+            frame_num: 0,
+            order_hint: 0,
+            input_image,
+            input_image_memory,
+            input_image_view,
+            input_image_layout,
+            dpb_images,
+            dpb_image_memories,
+            dpb_image_views,
+            dpb_slot_count: requested_dpb_slots,
+            bitstream_buffer,
+            bitstream_buffer_memory,
+            bitstream_buffer_ptr,
+            command_pool,
+            upload_command_buffer,
+            upload_fence,
+            encode_command_buffer,
+            encode_fence,
+            query_pool,
+            header_data: None,
+            current_dpb_slot: 0,
+            references: Vec::new(),
+            active_reference_count: target_active_refs as u32,
+        })
+    }
+}

--- a/src/encoder/av1/mod.rs
+++ b/src/encoder/av1/mod.rs
@@ -1,0 +1,417 @@
+//! AV1 encoder implementation using Vulkan Video.
+//!
+//! This module implements AV1 video encoding using Vulkan Video extensions.
+
+mod api;
+mod encode;
+mod init;
+
+use ash::vk;
+use tracing::debug;
+
+use crate::encoder::resources::{upload_image_to_input, UploadParams};
+use crate::error::Result;
+
+use crate::encoder::gop::GopStructure;
+use crate::encoder::EncodeConfig;
+use crate::vulkan::VideoContext;
+
+/// Minimum bitstream buffer size.
+const MIN_BITSTREAM_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+
+/// AV1 superblock size in pixels (128x128 for most cases).
+pub const SUPERBLOCK_SIZE: u32 = 128;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ReferenceInfo {
+    pub dpb_slot: u8,
+    pub order_hint: u32,
+}
+
+/// AV1 encoder.
+pub struct AV1Encoder {
+    context: VideoContext,
+    config: EncodeConfig,
+    gop: GopStructure,
+
+    // Video session.
+    video_queue_fn: ash::khr::video_queue::Device,
+    video_encode_fn: ash::khr::video_encode_queue::Device,
+    session: vk::VideoSessionKHR,
+    session_params: vk::VideoSessionParametersKHR,
+    session_memory: Vec<vk::DeviceMemory>,
+
+    // Frame counters.
+    input_frame_num: u64,
+    encode_frame_num: u64,
+    frame_num: u32,
+    order_hint: u32,
+
+    // Resources
+    input_image: vk::Image,
+    input_image_memory: vk::DeviceMemory,
+    input_image_view: vk::ImageView,
+    /// Current Vulkan image layout of `input_image` (tracked to avoid UB when transitioning).
+    input_image_layout: vk::ImageLayout,
+    /// DPB images for reference frames.
+    dpb_images: Vec<vk::Image>,
+    dpb_image_memories: Vec<vk::DeviceMemory>,
+    dpb_image_views: Vec<vk::ImageView>,
+    /// Number of DPB slots allocated.
+    dpb_slot_count: usize,
+    bitstream_buffer: vk::Buffer,
+    bitstream_buffer_memory: vk::DeviceMemory,
+    /// Persistently mapped pointer to the bitstream buffer (avoids per-frame map/unmap).
+    bitstream_buffer_ptr: *mut u8,
+
+    // Command resources.
+    command_pool: vk::CommandPool,
+    upload_command_buffer: vk::CommandBuffer,
+    upload_fence: vk::Fence,
+    encode_command_buffer: vk::CommandBuffer,
+    encode_fence: vk::Fence,
+    query_pool: vk::QueryPool,
+
+    // Cached AV1 sequence header OBU (retrieved from session parameters).
+    header_data: Option<Vec<u8>>,
+
+    // Reference picture tracking.
+    /// Current DPB slot to use for setup (the reconstructed picture).
+    current_dpb_slot: u8,
+    /// Active reference pictures. Ordered from most recent to oldest.
+    references: Vec<ReferenceInfo>,
+    /// Number of active reference frames (as configured/negotiated).
+    active_reference_count: u32,
+}
+
+impl AV1Encoder {
+    /// Upload input frame from a GPU image.
+    ///
+    /// This copies from a source image directly to the encoder's input image,
+    /// avoiding any CPU-side data copies. The source image must match the
+    /// encoder's configured pixel format and dimensions, and should be in
+    /// GENERAL layout.
+    fn upload_from_image(&mut self, src_image: vk::Image) -> Result<()> {
+        if src_image == self.input_image {
+            debug!("Source image is the encoder's input image, skipping upload copy");
+            return Ok(());
+        }
+
+        let params = UploadParams {
+            upload_command_buffer: self.upload_command_buffer,
+            upload_fence: self.upload_fence,
+            src_image,
+            dst_image: self.input_image,
+            width: self.config.dimensions.width,
+            height: self.config.dimensions.height,
+            pixel_format: self.config.pixel_format,
+            input_image_layout: self.input_image_layout,
+        };
+
+        upload_image_to_input(&self.context, &params)?;
+
+        // Update tracked layout.
+        self.input_image_layout = vk::ImageLayout::VIDEO_ENCODE_SRC_KHR;
+
+        Ok(())
+    }
+}
+
+// SAFETY: The raw pointer bitstream_buffer_ptr is only used within the encoder's
+// thread and is properly synchronized via Vulkan fences before access
+unsafe impl Send for AV1Encoder {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_superblock_size() {
+        assert_eq!(SUPERBLOCK_SIZE, 128);
+    }
+
+    #[test]
+    fn test_superblock_alignment() {
+        // Dimensions should be aligned up to superblock boundaries.
+        let align = |v: u32| (v + SUPERBLOCK_SIZE - 1) & !(SUPERBLOCK_SIZE - 1);
+
+        assert_eq!(align(1920), 1920); // Already aligned
+        assert_eq!(align(1080), 1152); // 1080 rounds up to 1152
+        assert_eq!(align(2560), 2560); // Already aligned
+        assert_eq!(align(1440), 1536); // 1440 rounds up to 1536
+        assert_eq!(align(1), 128); // Minimum is one superblock
+    }
+
+    #[test]
+    fn test_reference_info() {
+        let ref_info = ReferenceInfo {
+            dpb_slot: 2,
+            order_hint: 42,
+        };
+
+        assert_eq!(ref_info.dpb_slot, 2);
+        assert_eq!(ref_info.order_hint, 42);
+
+        // Should be Copy + Clone.
+        let copied = ref_info;
+        assert_eq!(copied.dpb_slot, ref_info.dpb_slot);
+        assert_eq!(copied.order_hint, ref_info.order_hint);
+    }
+
+    #[test]
+    fn test_order_hint_wrapping() {
+        // AV1 order hints are 8-bit, wrapping at 256.
+        let mut order_hint: u32 = 254;
+        for _ in 0..4 {
+            order_hint = (order_hint + 1) & 0xFF;
+        }
+        // 254 -> 255 -> 0 -> 1 -> 2
+        assert_eq!(order_hint, 2);
+    }
+
+    #[test]
+    fn test_reference_tracking() {
+        // Simulate building up a reference list like the encoder does.
+        let mut references: Vec<ReferenceInfo> = Vec::new();
+        let max_refs = 4usize;
+
+        for i in 0..6u8 {
+            let ref_info = ReferenceInfo {
+                dpb_slot: i % max_refs as u8,
+                order_hint: i as u32,
+            };
+            references.insert(0, ref_info);
+            while references.len() > max_refs {
+                references.pop();
+            }
+        }
+
+        // Should have exactly max_refs entries.
+        assert_eq!(references.len(), max_refs);
+        // Most recent should be first.
+        assert_eq!(references[0].order_hint, 5);
+        assert_eq!(references[max_refs - 1].order_hint, 2);
+    }
+
+    #[test]
+    fn test_key_frame_clears_references() {
+        // Simulate the encoder's key frame behavior: references.clear() on IDR.
+        let mut references: Vec<ReferenceInfo> = Vec::new();
+
+        // Build up some references (like a sequence of P-frames).
+        for i in 0..3u8 {
+            references.insert(0, ReferenceInfo {
+                dpb_slot: i,
+                order_hint: i as u32,
+            });
+        }
+        assert_eq!(references.len(), 3);
+
+        // Key frame resets everything.
+        references.clear();
+        assert!(references.is_empty());
+
+        // First frame after key should start fresh at slot 0.
+        references.insert(0, ReferenceInfo {
+            dpb_slot: 0,
+            order_hint: 0,
+        });
+        assert_eq!(references.len(), 1);
+        assert_eq!(references[0].dpb_slot, 0);
+        assert_eq!(references[0].order_hint, 0);
+    }
+
+    #[test]
+    fn test_dpb_slot_reuse() {
+        // Simulate the encoder's DPB slot allocation: after encoding a reference
+        // frame, find the first slot not used by any active reference.
+        let max_refs = 2usize;
+        let dpb_slot_count = 3u8; // active_refs + 1
+        let mut references: Vec<ReferenceInfo> = Vec::new();
+        let mut current_dpb_slot: u8 = 0;
+
+        // Helper: find next free slot (mirrors api.rs logic).
+        let find_free_slot = |refs: &[ReferenceInfo], slot_count: u8| -> u8 {
+            let used: Vec<u8> = refs.iter().map(|r| r.dpb_slot).collect();
+            for i in 0..slot_count {
+                if !used.contains(&i) {
+                    return i;
+                }
+            }
+            0 // fallback (shouldn't happen with correct slot_count)
+        };
+
+        // Frame 0 (IDR): uses slot 0.
+        assert_eq!(current_dpb_slot, 0);
+        references.insert(0, ReferenceInfo { dpb_slot: 0, order_hint: 0 });
+        while references.len() > max_refs { references.pop(); }
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+        assert_eq!(current_dpb_slot, 1); // slot 0 is used, next free is 1
+
+        // Frame 1 (P): uses slot 1.
+        references.insert(0, ReferenceInfo { dpb_slot: 1, order_hint: 1 });
+        while references.len() > max_refs { references.pop(); }
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+        assert_eq!(current_dpb_slot, 2); // slots 0,1 used, next free is 2
+
+        // Frame 2 (P): uses slot 2. Now all 3 slots have been touched,
+        // but max_refs=2 means the oldest reference (slot 0) gets evicted.
+        references.insert(0, ReferenceInfo { dpb_slot: 2, order_hint: 2 });
+        while references.len() > max_refs { references.pop(); }
+        // references = [{slot:2, hint:2}, {slot:1, hint:1}] - slot 0 evicted
+        assert_eq!(references.len(), 2);
+        assert_eq!(references[0].dpb_slot, 2);
+        assert_eq!(references[1].dpb_slot, 1);
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+        assert_eq!(current_dpb_slot, 0); // slot 0 is now free again (reuse!)
+
+        // Frame 3 (P): uses recycled slot 0.
+        references.insert(0, ReferenceInfo { dpb_slot: 0, order_hint: 3 });
+        while references.len() > max_refs { references.pop(); }
+        // references = [{slot:0, hint:3}, {slot:2, hint:2}] - slot 1 evicted
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+        assert_eq!(current_dpb_slot, 1); // slot 1 recycled
+    }
+
+    #[test]
+    fn test_idr_p_p_idr_cycle() {
+        // Full GOP cycle: IDR -> P -> P -> IDR, verifying DPB slot allocation
+        // and reference list state at each step.
+        let max_refs = 2usize;
+        let dpb_slot_count = 3u8;
+        let mut references: Vec<ReferenceInfo> = Vec::new();
+        let mut current_dpb_slot: u8 = 0;
+
+        let find_free_slot = |refs: &[ReferenceInfo], slot_count: u8| -> u8 {
+            let used: Vec<u8> = refs.iter().map(|r| r.dpb_slot).collect();
+            for i in 0..slot_count {
+                if !used.contains(&i) {
+                    return i;
+                }
+            }
+            0
+        };
+
+        // IDR frame: clears refs, writes to slot 0.
+        references.clear();
+        references.insert(0, ReferenceInfo { dpb_slot: current_dpb_slot, order_hint: 0 });
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+
+        assert_eq!(references.len(), 1);
+        assert_eq!(references[0].order_hint, 0);
+        assert_eq!(current_dpb_slot, 1);
+
+        // P frame 1: writes to slot 1.
+        references.insert(0, ReferenceInfo { dpb_slot: current_dpb_slot, order_hint: 1 });
+        while references.len() > max_refs { references.pop(); }
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+
+        assert_eq!(references.len(), 2);
+        assert_eq!(references[0].order_hint, 1);
+        assert_eq!(current_dpb_slot, 2);
+
+        // P frame 2: writes to slot 2, evicts oldest ref (slot 0).
+        references.insert(0, ReferenceInfo { dpb_slot: current_dpb_slot, order_hint: 2 });
+        while references.len() > max_refs { references.pop(); }
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+
+        assert_eq!(references.len(), 2);
+        assert_eq!(references[0].order_hint, 2);
+        assert_eq!(current_dpb_slot, 0); // slot 0 recycled
+
+        // Second IDR: everything resets.
+        references.clear();
+        assert!(references.is_empty());
+    }
+
+    #[test]
+    fn test_single_reference_slot() {
+        // Edge case: only 1 active reference with 2 DPB slots (minimum viable).
+        let max_refs = 1usize;
+        let dpb_slot_count = 2u8;
+        let mut references: Vec<ReferenceInfo> = Vec::new();
+
+        let find_free_slot = |refs: &[ReferenceInfo], slot_count: u8| -> u8 {
+            let used: Vec<u8> = refs.iter().map(|r| r.dpb_slot).collect();
+            for i in 0..slot_count {
+                if !used.contains(&i) {
+                    return i;
+                }
+            }
+            0
+        };
+
+        // Frame 0: slot 0.
+        references.insert(0, ReferenceInfo { dpb_slot: 0, order_hint: 0 });
+        while references.len() > max_refs { references.pop(); }
+        let mut current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+        assert_eq!(current_dpb_slot, 1);
+
+        // Frame 1: slot 1. Old ref (slot 0) evicted since max_refs=1.
+        references.insert(0, ReferenceInfo { dpb_slot: 1, order_hint: 1 });
+        while references.len() > max_refs { references.pop(); }
+        assert_eq!(references.len(), 1);
+        assert_eq!(references[0].dpb_slot, 1);
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+        assert_eq!(current_dpb_slot, 0); // ping-pong between 0 and 1
+
+        // Frame 2: slot 0 again.
+        references.insert(0, ReferenceInfo { dpb_slot: 0, order_hint: 2 });
+        while references.len() > max_refs { references.pop(); }
+        current_dpb_slot = find_free_slot(&references, dpb_slot_count);
+        assert_eq!(current_dpb_slot, 1); // ping-pong back
+    }
+}
+
+impl Drop for AV1Encoder {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = self.context.device().device_wait_idle();
+            self.context
+                .device()
+                .destroy_query_pool(self.query_pool, None);
+            self.context.device().destroy_fence(self.upload_fence, None);
+            self.context.device().destroy_fence(self.encode_fence, None);
+            self.context
+                .device()
+                .destroy_command_pool(self.command_pool, None);
+            self.context
+                .device()
+                .destroy_buffer(self.bitstream_buffer, None);
+            // Unmap the persistently mapped bitstream buffer before freeing memory.
+            self.context
+                .device()
+                .unmap_memory(self.bitstream_buffer_memory);
+            self.context
+                .device()
+                .free_memory(self.bitstream_buffer_memory, None);
+            self.context
+                .device()
+                .destroy_image_view(self.input_image_view, None);
+            self.context.device().destroy_image(self.input_image, None);
+            self.context
+                .device()
+                .free_memory(self.input_image_memory, None);
+
+            for i in 0..self.dpb_images.len() {
+                self.context
+                    .device()
+                    .destroy_image_view(self.dpb_image_views[i], None);
+                self.context
+                    .device()
+                    .destroy_image(self.dpb_images[i], None);
+                self.context
+                    .device()
+                    .free_memory(self.dpb_image_memories[i], None);
+            }
+
+            self.video_queue_fn
+                .destroy_video_session_parameters(self.session_params, None);
+            self.video_queue_fn
+                .destroy_video_session(self.session, None);
+            for mem in &self.session_memory {
+                self.context.device().free_memory(*mem, None);
+            }
+        }
+    }
+}

--- a/src/encoder/av1/mod.rs
+++ b/src/encoder/av1/mod.rs
@@ -200,10 +200,13 @@ mod tests {
 
         // Build up some references (like a sequence of P-frames).
         for i in 0..3u8 {
-            references.insert(0, ReferenceInfo {
-                dpb_slot: i,
-                order_hint: i as u32,
-            });
+            references.insert(
+                0,
+                ReferenceInfo {
+                    dpb_slot: i,
+                    order_hint: i as u32,
+                },
+            );
         }
         assert_eq!(references.len(), 3);
 
@@ -212,10 +215,13 @@ mod tests {
         assert!(references.is_empty());
 
         // First frame after key should start fresh at slot 0.
-        references.insert(0, ReferenceInfo {
-            dpb_slot: 0,
-            order_hint: 0,
-        });
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: 0,
+                order_hint: 0,
+            },
+        );
         assert_eq!(references.len(), 1);
         assert_eq!(references[0].dpb_slot, 0);
         assert_eq!(references[0].order_hint, 0);
@@ -243,21 +249,45 @@ mod tests {
 
         // Frame 0 (IDR): uses slot 0.
         assert_eq!(current_dpb_slot, 0);
-        references.insert(0, ReferenceInfo { dpb_slot: 0, order_hint: 0 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: 0,
+                order_hint: 0,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         current_dpb_slot = find_free_slot(&references, dpb_slot_count);
         assert_eq!(current_dpb_slot, 1); // slot 0 is used, next free is 1
 
         // Frame 1 (P): uses slot 1.
-        references.insert(0, ReferenceInfo { dpb_slot: 1, order_hint: 1 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: 1,
+                order_hint: 1,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         current_dpb_slot = find_free_slot(&references, dpb_slot_count);
         assert_eq!(current_dpb_slot, 2); // slots 0,1 used, next free is 2
 
         // Frame 2 (P): uses slot 2. Now all 3 slots have been touched,
         // but max_refs=2 means the oldest reference (slot 0) gets evicted.
-        references.insert(0, ReferenceInfo { dpb_slot: 2, order_hint: 2 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: 2,
+                order_hint: 2,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         // references = [{slot:2, hint:2}, {slot:1, hint:1}] - slot 0 evicted
         assert_eq!(references.len(), 2);
         assert_eq!(references[0].dpb_slot, 2);
@@ -266,8 +296,16 @@ mod tests {
         assert_eq!(current_dpb_slot, 0); // slot 0 is now free again (reuse!)
 
         // Frame 3 (P): uses recycled slot 0.
-        references.insert(0, ReferenceInfo { dpb_slot: 0, order_hint: 3 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: 0,
+                order_hint: 3,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         // references = [{slot:0, hint:3}, {slot:2, hint:2}] - slot 1 evicted
         current_dpb_slot = find_free_slot(&references, dpb_slot_count);
         assert_eq!(current_dpb_slot, 1); // slot 1 recycled
@@ -294,7 +332,13 @@ mod tests {
 
         // IDR frame: clears refs, writes to slot 0.
         references.clear();
-        references.insert(0, ReferenceInfo { dpb_slot: current_dpb_slot, order_hint: 0 });
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: current_dpb_slot,
+                order_hint: 0,
+            },
+        );
         current_dpb_slot = find_free_slot(&references, dpb_slot_count);
 
         assert_eq!(references.len(), 1);
@@ -302,8 +346,16 @@ mod tests {
         assert_eq!(current_dpb_slot, 1);
 
         // P frame 1: writes to slot 1.
-        references.insert(0, ReferenceInfo { dpb_slot: current_dpb_slot, order_hint: 1 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: current_dpb_slot,
+                order_hint: 1,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         current_dpb_slot = find_free_slot(&references, dpb_slot_count);
 
         assert_eq!(references.len(), 2);
@@ -311,8 +363,16 @@ mod tests {
         assert_eq!(current_dpb_slot, 2);
 
         // P frame 2: writes to slot 2, evicts oldest ref (slot 0).
-        references.insert(0, ReferenceInfo { dpb_slot: current_dpb_slot, order_hint: 2 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: current_dpb_slot,
+                order_hint: 2,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         current_dpb_slot = find_free_slot(&references, dpb_slot_count);
 
         assert_eq!(references.len(), 2);
@@ -342,22 +402,46 @@ mod tests {
         };
 
         // Frame 0: slot 0.
-        references.insert(0, ReferenceInfo { dpb_slot: 0, order_hint: 0 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: 0,
+                order_hint: 0,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         let mut current_dpb_slot = find_free_slot(&references, dpb_slot_count);
         assert_eq!(current_dpb_slot, 1);
 
         // Frame 1: slot 1. Old ref (slot 0) evicted since max_refs=1.
-        references.insert(0, ReferenceInfo { dpb_slot: 1, order_hint: 1 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: 1,
+                order_hint: 1,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         assert_eq!(references.len(), 1);
         assert_eq!(references[0].dpb_slot, 1);
         current_dpb_slot = find_free_slot(&references, dpb_slot_count);
         assert_eq!(current_dpb_slot, 0); // ping-pong between 0 and 1
 
         // Frame 2: slot 0 again.
-        references.insert(0, ReferenceInfo { dpb_slot: 0, order_hint: 2 });
-        while references.len() > max_refs { references.pop(); }
+        references.insert(
+            0,
+            ReferenceInfo {
+                dpb_slot: 0,
+                order_hint: 2,
+            },
+        );
+        while references.len() > max_refs {
+            references.pop();
+        }
         current_dpb_slot = find_free_slot(&references, dpb_slot_count);
         assert_eq!(current_dpb_slot, 1); // ping-pong back
     }


### PR DESCRIPTION
:wave: I reached out on the moonlight discord about this work - here's the cleaned up version.

This adds AV1 support for pixelforge - the work was done in conjunction with some partner moonshine PRs which I will link here as soon as they're open:
- https://github.com/hgaiser/moonshine/pull/18
- https://github.com/hgaiser/moonshine/pull/19

[ash has begun adding av1 encode support in the update branch](https://github.com/ash-rs/ash/tree/update)  - so this is mostly work implementing that. Note that this does involve changing the source for ash from the previously pinned main branch commit to a feature branch commit hash from the `update` branch.

A lot of this was put together using ffmpeg's av1 vulkan encoding as a reference implementation, and with a good bit of help from an LLM for questions that I had along the way. I'm hardly a graphics programmer, so this is definitely outside of my are of expertise. I also to a lesser extent consulted [Khronos Group Vulkan-Headers repo](https://github.com/KhronosGroup/Vulkan-Headers) and [nvpro-samples vk_video_samples repo](https://github.com/nvpro-samples/vk_video_samples).

It should align with all the rate control and zero copy DMA-BUF, and color profile stuff other encoders in pixelforge currently support.

There's a bunch of av1 stuff here that isn't really working (bframe, tiling) which I barely understand the usecase for but seem not relevant for streaming video like moonshine is doing, and don't seem implemented in the other encoders.

I've tested using moonshine as a client on a 9070XT GPU on a fedora 43 (atomic) system with mesa 25.3.3. Additional testing on more hardware would be great, but is probably easier to do through Moonshine when the AV1 PR on that repo is posted, probably tomorrow night.