### PR TITLE
feat: Cleaner p_next handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,9 @@ A Vulkan-based video encoding library for Rust, supporting H.264, H.265, and AV1
 
 | Codec | Encode |
 |-------|--------|
-| H.264/AVC | ✓ |
+| H.264/AVC  | ✓ |
 | H.265/HEVC | ✓ |
-| AV1 | ✓ (experimental) |
-
-> ⚠️ **AV1 Warning**: AV1 encoding is experimental. On NVIDIA GPUs, P-frames cannot
-> reference other P-frames, causing all P-frames to reference the I-frame instead. This
-> leads to progressively larger frame sizes over time. Consider using H.264 or HEVC
-> until this is resolved.
+| AV1        | ✓ |
 
 ## Requirements
 

--- a/examples/query_capabilities.rs
+++ b/examples/query_capabilities.rs
@@ -4,6 +4,7 @@
 //! from the Vulkan video extensions.
 
 use ash::vk;
+use ash::vk::TaggedStructure;
 use pixelforge::{Codec, VideoContextBuilder};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
@@ -37,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Codec Support:");
     println!("--------------");
 
-    let codecs = [Codec::H264, Codec::H265];
+    let codecs = [Codec::H264, Codec::H265, Codec::AV1];
 
     for codec in codecs {
         println!("\n{:?}:", codec);
@@ -95,7 +96,7 @@ fn query_detailed_capabilities(
         println!("    Checking {}: ", desc);
 
         // Construct profile info
-        let (mut profile_info, mut h264_profile, mut h265_profile) = match codec {
+        let (mut profile_info, mut h264_profile, mut h265_profile, mut av1_profile) = match codec {
             Codec::H264 => {
                 let profile_idc = if subsampling == vk::VideoChromaSubsamplingFlagsKHR::TYPE_444 {
                     ash::vk::native::StdVideoH264ProfileIdc_STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE
@@ -110,7 +111,7 @@ fn query_detailed_capabilities(
                     .chroma_subsampling(subsampling)
                     .luma_bit_depth(bit_depth)
                     .chroma_bit_depth(bit_depth);
-                (info, Some(h264), None)
+                (info, Some(h264), None, None)
             }
             Codec::H265 => {
                 let profile_idc = if subsampling == vk::VideoChromaSubsamplingFlagsKHR::TYPE_444 {
@@ -128,30 +129,46 @@ fn query_detailed_capabilities(
                     .chroma_subsampling(subsampling)
                     .luma_bit_depth(bit_depth)
                     .chroma_bit_depth(bit_depth);
-                (info, None, Some(h265))
+                (info, None, Some(h265), None)
             }
-            _ => return Ok(()),
+            Codec::AV1 => {
+                let profile = if subsampling == vk::VideoChromaSubsamplingFlagsKHR::TYPE_444 {
+                    ash::vk::native::StdVideoAV1Profile_STD_VIDEO_AV1_PROFILE_HIGH
+                } else {
+                    ash::vk::native::StdVideoAV1Profile_STD_VIDEO_AV1_PROFILE_MAIN
+                };
+
+                let av1 = vk::VideoEncodeAV1ProfileInfoKHR::default().std_profile(profile);
+                let info = vk::VideoProfileInfoKHR::default()
+                    .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_AV1)
+                    .chroma_subsampling(subsampling)
+                    .luma_bit_depth(bit_depth)
+                    .chroma_bit_depth(bit_depth);
+                (info, None, None, Some(av1))
+            }
         };
 
         if let Some(h264) = &mut h264_profile {
-            profile_info.p_next = (h264 as *mut vk::VideoEncodeH264ProfileInfoKHR).cast();
+            profile_info = profile_info.push(h264);
         }
         if let Some(h265) = &mut h265_profile {
-            profile_info.p_next = (h265 as *mut vk::VideoEncodeH265ProfileInfoKHR).cast();
+            profile_info = profile_info.push(h265);
+        }
+        if let Some(av1) = &mut av1_profile {
+            profile_info = profile_info.push(av1);
         }
 
         // 1. Query Video Capabilities
-        let mut caps = vk::VideoCapabilitiesKHR::default();
         let mut encode_caps = vk::VideoEncodeCapabilitiesKHR::default();
-        caps.p_next = (&mut encode_caps as *mut vk::VideoEncodeCapabilitiesKHR).cast();
+        let mut caps = vk::VideoCapabilitiesKHR::default().push(&mut encode_caps);
 
         let mut h264_caps = vk::VideoEncodeH264CapabilitiesKHR::default();
         let mut h265_caps = vk::VideoEncodeH265CapabilitiesKHR::default();
-
-        if codec == Codec::H264 {
-            encode_caps.p_next = (&mut h264_caps as *mut vk::VideoEncodeH264CapabilitiesKHR).cast();
-        } else if codec == Codec::H265 {
-            encode_caps.p_next = (&mut h265_caps as *mut vk::VideoEncodeH265CapabilitiesKHR).cast();
+        let mut av1_caps = vk::VideoEncodeAV1CapabilitiesKHR::default();
+        match codec {
+            Codec::H264 => caps = caps.push(&mut h264_caps),
+            Codec::H265 => caps = caps.push(&mut h265_caps),
+            Codec::AV1 => caps = caps.push(&mut av1_caps),
         }
 
         let result = unsafe {
@@ -185,9 +202,9 @@ fn query_detailed_capabilities(
             vk::VideoProfileListInfoKHR::default().profiles(std::slice::from_ref(&profile_info));
 
         // Check for Input Image support (VIDEO_ENCODE_SRC_KHR)
-        let mut format_info = vk::PhysicalDeviceVideoFormatInfoKHR::default()
-            .image_usage(vk::ImageUsageFlags::VIDEO_ENCODE_SRC_KHR);
-        format_info.p_next = (&mut format_props_list as *mut vk::VideoProfileListInfoKHR).cast();
+        let format_info = vk::PhysicalDeviceVideoFormatInfoKHR::default()
+            .image_usage(vk::ImageUsageFlags::VIDEO_ENCODE_SRC_KHR)
+            .push(&mut format_props_list);
 
         let result = unsafe {
             (video_queue_fn
@@ -220,9 +237,9 @@ fn query_detailed_capabilities(
         }
 
         // Check for DPB Image support (VIDEO_ENCODE_DPB_KHR)
-        let mut format_info = vk::PhysicalDeviceVideoFormatInfoKHR::default()
-            .image_usage(vk::ImageUsageFlags::VIDEO_ENCODE_DPB_KHR);
-        format_info.p_next = (&mut format_props_list as *mut vk::VideoProfileListInfoKHR).cast();
+        let format_info = vk::PhysicalDeviceVideoFormatInfoKHR::default()
+            .image_usage(vk::ImageUsageFlags::VIDEO_ENCODE_DPB_KHR)
+            .push(&mut format_props_list);
 
         let mut format_props_count = 0;
         let result = unsafe {

--- a/src/converter/pipeline.rs
+++ b/src/converter/pipeline.rs
@@ -8,6 +8,7 @@ use crate::encoder::resources::find_memory_type;
 use crate::error::{PixelForgeError, Result};
 use crate::vulkan::VideoContext;
 use ash::vk;
+use ash::vk::TaggedStructure;
 
 /// Precompiled SPIR-V bytecode for the color conversion compute shader.
 const COLOR_CONVERT_SPIRV_BYTES: &[u8] = include_bytes!("../../shader/color_convert.spv");
@@ -153,10 +154,7 @@ pub fn create_converter(
     // runtime descriptor population. The correct sizes for in-buffer
     // descriptors are the regular `*_descriptor_size` fields.
     let mut db_props = vk::PhysicalDeviceDescriptorBufferPropertiesEXT::default();
-    let mut props = vk::PhysicalDeviceProperties2 {
-        p_next: &mut db_props as *mut _ as *mut _,
-        ..Default::default()
-    };
+    let mut props = vk::PhysicalDeviceProperties2::default().push(&mut db_props);
     unsafe {
         instance.get_physical_device_properties2(physical_device, &mut props);
     }

--- a/src/encoder/av1/api.rs
+++ b/src/encoder/av1/api.rs
@@ -69,10 +69,6 @@ impl AV1Encoder {
             self.order_hint = 0;
             // Reset references for key frames.
             self.references.clear();
-            // Reset DPB slot activation tracking on key frame - all slots become inactive.
-            for active in &mut self.dpb_slot_active {
-                *active = false;
-            }
         }
 
         let mut encoded_data = Vec::new();
@@ -107,29 +103,42 @@ impl AV1Encoder {
         self.frame_num += 1;
         self.order_hint = (self.order_hint + 1) & 0xFF; // 8-bit order hint
 
-        // Only KEY frames are stored as references. P frames all reference the KEY frame
-        // and don't update any reference buffer, avoiding P→P which produces corrupt output
-        // on NVIDIA AV1 encoders.
-        if is_key_frame {
-            let ref_info = super::ReferenceInfo {
-                dpb_slot: self.current_dpb_slot,
-                order_hint: encoded_order_hint,
-                frame_type: ash::vk::native::StdVideoAV1FrameType_STD_VIDEO_AV1_FRAME_TYPE_KEY,
-            };
-            self.references.clear();
-            self.references.push(ref_info);
+        // Update reference frames and DPB slot management
+        // Key frames refresh all reference slots. Inter frames refresh only their own slot,
+        //  becoming the new LAST_FRAME for the next inter frame
+        let ref_info = super::ReferenceInfo {
+            dpb_slot: self.current_dpb_slot,
+            order_hint: encoded_order_hint,
+            frame_type: if is_key_frame {
+                ash::vk::native::StdVideoAV1FrameType_STD_VIDEO_AV1_FRAME_TYPE_KEY
+            } else {
+                ash::vk::native::StdVideoAV1FrameType_STD_VIDEO_AV1_FRAME_TYPE_INTER
+            },
+        };
 
-            // KEY frame uses the current DPB slot; pick a different one for P frames.
-            let used_slots: Vec<u8> = self.references.iter().map(|r| r.dpb_slot).collect();
+        // Store the encoded frame as the most recent reference
+        if is_key_frame {
+            self.references.clear();
+        }
+        self.references.insert(0, ref_info);
+        // Keep only the most recent reference for single-reference prediction
+        self.references.truncate(1);
+
+        // Cycle to next available DPB slot for the next frame
+        let used_slots: Vec<u8> = self.references.iter().map(|r| r.dpb_slot).collect();
+        let mut next_slot = (self.current_dpb_slot + 1) % self.dpb_slot_count as u8;
+
+        // If the next slot is in use, find the first available slot
+        if used_slots.contains(&next_slot) {
             for i in 0..self.dpb_slot_count as u8 {
                 if !used_slots.contains(&i) {
-                    self.current_dpb_slot = i;
+                    next_slot = i;
                     break;
                 }
             }
         }
-        // P frames reuse the same scratch DPB slot (current_dpb_slot stays unchanged
-        // between P frames since it's always different from the KEY frame's slot).
+
+        self.current_dpb_slot = next_slot;
 
         Ok(EncodedPacket {
             data: encoded_data,

--- a/src/encoder/av1/encode.rs
+++ b/src/encoder/av1/encode.rs
@@ -392,17 +392,26 @@ impl AV1Encoder {
         // Begin video coding with rate control info for non-first frames.
         let is_first_frame = self.encode_frame_num == 0;
 
+        // AV1-specific rate control info.
+        let mut av1_rc_info = vk::VideoEncodeAV1RateControlInfoKHR::default()
+            .gop_frame_count(self.config.gop_size)
+            .key_frame_period(self.config.gop_size)
+            .consecutive_bipredictive_frame_count(0)
+            .temporal_layer_count(1);
+
         let begin_coding_info = if is_first_frame {
             vk::VideoBeginCodingInfoKHR::default()
                 .video_session(self.session)
                 .video_session_parameters(self.session_params)
                 .reference_slots(&all_reference_slots)
+                .push(&mut av1_rc_info)
         } else {
             vk::VideoBeginCodingInfoKHR::default()
                 .video_session(self.session)
                 .video_session_parameters(self.session_params)
                 .reference_slots(&all_reference_slots)
                 .push(&mut rc_info)
+                .push(&mut av1_rc_info)
         };
 
         unsafe {
@@ -414,13 +423,6 @@ impl AV1Encoder {
         // Combine RESET + RATE_CONTROL + QUALITY_LEVEL into a single control command.
         // This matches the H265 approach and is required for AMD RADV.
         if is_first_frame {
-            // AV1-specific rate control info.
-            let mut av1_rc_info = vk::VideoEncodeAV1RateControlInfoKHR::default()
-                .gop_frame_count(self.config.gop_size)
-                .key_frame_period(self.config.gop_size)
-                .consecutive_bipredictive_frame_count(0)
-                .temporal_layer_count(1);
-
             let mut quality_level_info =
                 vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
 

--- a/src/encoder/av1/encode.rs
+++ b/src/encoder/av1/encode.rs
@@ -432,6 +432,7 @@ impl AV1Encoder {
                         | vk::VideoCodingControlFlagsKHR::ENCODE_RATE_CONTROL
                         | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
                 )
+                .push(&mut rc_info)
                 .push(&mut av1_rc_info)
                 .push(&mut quality_level_info);
 

--- a/src/encoder/av1/encode.rs
+++ b/src/encoder/av1/encode.rs
@@ -107,6 +107,7 @@ impl AV1Encoder {
             .coded_extent(frame_extent)
             .base_array_layer(0)
             .image_view_binding(self.dpb_image_views[self.current_dpb_slot as usize]);
+
         // AV1 reference info for the setup slot.
         let reference_info_flags = ash::vk::native::StdVideoEncodeAV1ReferenceInfoFlags {
             _bitfield_align_1: [],
@@ -132,7 +133,7 @@ impl AV1Encoder {
         let mut setup_av1_dpb_info =
             vk::VideoEncodeAV1DpbSlotInfoKHR::default().std_reference_info(&std_reference_info);
 
-        let mut setup_av1_dpb_info_ref0 = setup_av1_dpb_info.clone();
+        let mut setup_av1_dpb_info_ref0 = setup_av1_dpb_info;
         let setup_reference_slot = vk::VideoReferenceSlotInfoKHR::default()
             .slot_index(self.current_dpb_slot as i32)
             .picture_resource(&setup_picture_resource)
@@ -243,24 +244,10 @@ impl AV1Encoder {
         // Note: If this causes issues, we may need to re-enable it with proper values.
 
         // Build ref_frame_idx, ref_order_hint, refresh_frame_flags, and primary_ref_frame.
-        //
-        // All P frames reference only the KEY frame (stored in buffer 0).
-        // P frames set refresh_frame_flags=0x00 (don't update any reference buffer).
-        // This avoids P→P references which produce corrupt output on NVIDIA AV1 encoders.
+        // For key frames: refresh all slots, all refs point to slot 0.
+        // For inter frames: LAST_FRAME points to most recent past frame, refresh only current slot.
         let (ref_frame_idx, ref_order_hint, primary_ref_frame, refresh_frame_flags) =
-            if !is_key_frame && !self.references.is_empty() {
-                // All reference names point to buffer 0 (where KEY frame lives).
-                let ref_idx = [0i8; 7];
-                let ref_info = &self.references[0];
-                let mut order_hints = [0u8; 8];
-                order_hints[0] = ref_info.order_hint as u8;
-
-                // P frames don't refresh any reference buffer.
-                (ref_idx, order_hints, 0u8, 0x00u8)
-            } else {
-                // KEY frame: refresh all buffers.
-                ([0i8; 7], [0u8; 8], 7u8, 0xFFu8)
-            };
+            self.calculate_reference_frame_mapping(is_key_frame);
 
         // AV1 encode picture info.
         let std_picture_info = ash::vk::native::StdVideoEncodeAV1PictureInfo {
@@ -548,5 +535,34 @@ impl AV1Encoder {
         self.dpb_slot_active[self.current_dpb_slot as usize] = true;
 
         Ok(encoded_data)
+    }
+
+    /// Calculate proper reference frame mapping for AV1 encoding.
+    fn calculate_reference_frame_mapping(&self, is_key_frame: bool) -> ([i8; 7], [u8; 8], u8, u8) {
+        if is_key_frame {
+            // Key frame refreshes all 8 reference slots
+            // All named references (LAST_FRAME, LAST2_FRAME, etc.) point to slot 0
+            ([0i8; 7], [0u8; 8], 7u8, 0xFFu8)
+        } else if !self.references.is_empty() {
+            let mut ref_frame_idx = [0i8; 7];
+            let mut ref_order_hint = [0u8; 8];
+
+            // Map LAST_FRAME (index 0) to our most recent reference's DPB slot
+            let last_ref = &self.references[0];
+            ref_frame_idx[0] = last_ref.dpb_slot as i8;
+            ref_order_hint[0] = last_ref.order_hint as u8;
+
+            // Other reference slots remain 0 (unused/pointing to nothing active)
+            // They'll be ignored since we're using SINGLE_REFERENCE prediction mode
+
+            // Refresh only the current DPB slot so this frame becomes the new LAST_FRAME
+            let refresh_flags = 1u8 << self.current_dpb_slot;
+
+            // primary_ref_frame = 0 means LAST_FRAME is our primary reference
+            (ref_frame_idx, ref_order_hint, 0u8, refresh_flags)
+        } else {
+            // No references available (shouldn't happen for inter frames)
+            ([0i8; 7], [0u8; 8], 7u8, 0x00u8)
+        }
     }
 }

--- a/src/encoder/av1/encode.rs
+++ b/src/encoder/av1/encode.rs
@@ -7,6 +7,7 @@ use crate::encoder::resources::{
 };
 use crate::error::{PixelForgeError, Result};
 use ash::vk;
+use ash::vk::TaggedStructure;
 use tracing::debug;
 
 impl AV1Encoder {
@@ -128,16 +129,14 @@ impl AV1Encoder {
         };
 
         // AV1 DPB slot info for the setup reference slot (the slot being written).
-        let setup_av1_dpb_info =
+        let mut setup_av1_dpb_info =
             vk::VideoEncodeAV1DpbSlotInfoKHR::default().std_reference_info(&std_reference_info);
 
-        let mut setup_reference_slot = vk::VideoReferenceSlotInfoKHR::default()
+        let mut setup_av1_dpb_info_ref0 = setup_av1_dpb_info.clone();
+        let setup_reference_slot = vk::VideoReferenceSlotInfoKHR::default()
             .slot_index(self.current_dpb_slot as i32)
-            .picture_resource(&setup_picture_resource);
-
-        // Attach AV1 DPB info to setup slot's pNext chain.
-        setup_reference_slot.p_next =
-            (&setup_av1_dpb_info as *const vk::VideoEncodeAV1DpbSlotInfoKHR).cast();
+            .picture_resource(&setup_picture_resource)
+            .push(&mut setup_av1_dpb_info_ref0);
 
         // Reference frames for inter frames.
         let mut reference_slots = Vec::new();
@@ -179,8 +178,7 @@ impl AV1Encoder {
                 .picture_resource(&ref_picture_resources[0]);
             reference_slots.push(ref_slot);
             // Now set pNext after it's in the vector at its final location.
-            reference_slots[0].p_next =
-                (&av1_reference_infos[0] as *const vk::VideoEncodeAV1DpbSlotInfoKHR).cast();
+            reference_slots[0] = reference_slots[0].push(&mut av1_reference_infos[0]);
         }
 
         // AV1 quantization parameters - required structure.
@@ -347,21 +345,14 @@ impl AV1Encoder {
             .use_max_q_index(true)
             .max_q_index(max_q_index);
 
-        let mut rc_layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
+        let rc_layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
             .average_bitrate(average_bitrate as u64)
             .max_bitrate(max_bitrate as u64)
             .frame_rate_numerator(self.config.frame_rate_numerator)
-            .frame_rate_denominator(self.config.frame_rate_denominator);
-        rc_layer_info.p_next =
-            (&mut av1_rc_layer_info as *mut vk::VideoEncodeAV1RateControlLayerInfoKHR).cast();
-        let rc_layers = [rc_layer_info];
+            .frame_rate_denominator(self.config.frame_rate_denominator)
+            .push(&mut av1_rc_layer_info);
 
-        // AV1-specific rate control info.
-        let mut av1_rc_info = vk::VideoEncodeAV1RateControlInfoKHR::default()
-            .gop_frame_count(self.config.gop_size)
-            .key_frame_period(self.config.gop_size)
-            .consecutive_bipredictive_frame_count(0)
-            .temporal_layer_count(1);
+        let rc_layers = [rc_layer_info];
 
         // Rate control info (matches H265 pattern: only add layers/buffer for non-DISABLED modes).
         let mut rc_info = vk::VideoEncodeRateControlInfoKHR::default().rate_control_mode(rc_mode);
@@ -371,7 +362,6 @@ impl AV1Encoder {
                 .layers(&rc_layers)
                 .virtual_buffer_size_in_ms(self.config.virtual_buffer_size_ms)
                 .initial_virtual_buffer_size_in_ms(self.config.initial_virtual_buffer_size_ms);
-            rc_info.p_next = (&mut av1_rc_info as *mut vk::VideoEncodeAV1RateControlInfoKHR).cast();
         }
 
         // Video begin coding info.
@@ -382,11 +372,10 @@ impl AV1Encoder {
         if is_reference {
             // Build a separate setup slot for begin coding with slot_index = -1.
             // This tells the implementation the slot is being set up, not yet active.
-            let mut setup_slot_for_begin = vk::VideoReferenceSlotInfoKHR::default()
+            let setup_slot_for_begin = vk::VideoReferenceSlotInfoKHR::default()
                 .slot_index(-1)
-                .picture_resource(&setup_picture_resource);
-            setup_slot_for_begin.p_next =
-                (&setup_av1_dpb_info as *const vk::VideoEncodeAV1DpbSlotInfoKHR).cast();
+                .picture_resource(&setup_picture_resource)
+                .push(&mut setup_av1_dpb_info);
             all_reference_slots.push(setup_slot_for_begin);
         }
 
@@ -409,12 +398,11 @@ impl AV1Encoder {
                 .video_session_parameters(self.session_params)
                 .reference_slots(&all_reference_slots)
         } else {
-            let mut info = vk::VideoBeginCodingInfoKHR::default()
+            vk::VideoBeginCodingInfoKHR::default()
                 .video_session(self.session)
                 .video_session_parameters(self.session_params)
-                .reference_slots(&all_reference_slots);
-            info.p_next = (&rc_info as *const vk::VideoEncodeRateControlInfoKHR).cast();
-            info
+                .reference_slots(&all_reference_slots)
+                .push(&mut rc_info)
         };
 
         unsafe {
@@ -426,18 +414,24 @@ impl AV1Encoder {
         // Combine RESET + RATE_CONTROL + QUALITY_LEVEL into a single control command.
         // This matches the H265 approach and is required for AMD RADV.
         if is_first_frame {
+            // AV1-specific rate control info.
+            let mut av1_rc_info = vk::VideoEncodeAV1RateControlInfoKHR::default()
+                .gop_frame_count(self.config.gop_size)
+                .key_frame_period(self.config.gop_size)
+                .consecutive_bipredictive_frame_count(0)
+                .temporal_layer_count(1);
+
             let mut quality_level_info =
                 vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
-            quality_level_info.p_next =
-                (&rc_info as *const vk::VideoEncodeRateControlInfoKHR).cast();
 
-            let mut control_info = vk::VideoCodingControlInfoKHR::default().flags(
-                vk::VideoCodingControlFlagsKHR::RESET
-                    | vk::VideoCodingControlFlagsKHR::ENCODE_RATE_CONTROL
-                    | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
-            );
-            control_info.p_next =
-                (&quality_level_info as *const vk::VideoEncodeQualityLevelInfoKHR).cast();
+            let control_info = vk::VideoCodingControlInfoKHR::default()
+                .flags(
+                    vk::VideoCodingControlFlagsKHR::RESET
+                        | vk::VideoCodingControlFlagsKHR::ENCODE_RATE_CONTROL
+                        | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
+                )
+                .push(&mut av1_rc_info)
+                .push(&mut quality_level_info);
 
             unsafe {
                 self.video_queue_fn
@@ -466,7 +460,7 @@ impl AV1Encoder {
             encode_info = encode_info.reference_slots(&reference_slots);
         }
 
-        encode_info.p_next = (&av1_picture_info as *const vk::VideoEncodeAV1PictureInfoKHR).cast();
+        encode_info = encode_info.push(&mut av1_picture_info);
 
         // Begin query to capture encode feedback (bitstream size, status).
         unsafe {

--- a/src/encoder/av1/encode.rs
+++ b/src/encoder/av1/encode.rs
@@ -329,21 +329,24 @@ impl AV1Encoder {
         }
 
         // AV1-specific rate control layer info.
-        let min_q_index = vk::VideoEncodeAV1QIndexKHR {
-            intra_q_index: qp,
-            predictive_q_index: qp,
-            bipredictive_q_index: qp,
-        };
-        let max_q_index = vk::VideoEncodeAV1QIndexKHR {
-            intra_q_index: qp,
-            predictive_q_index: qp,
-            bipredictive_q_index: qp,
-        };
-        let mut av1_rc_layer_info = vk::VideoEncodeAV1RateControlLayerInfoKHR::default()
-            .use_min_q_index(true)
-            .min_q_index(min_q_index)
-            .use_max_q_index(true)
-            .max_q_index(max_q_index);
+        let mut av1_rc_layer_info = vk::VideoEncodeAV1RateControlLayerInfoKHR::default();
+        if rc_mode == vk::VideoEncodeRateControlModeFlagsKHR::DISABLED {
+            let q_index = vk::VideoEncodeAV1QIndexKHR {
+                intra_q_index: qp,
+                predictive_q_index: qp,
+                bipredictive_q_index: qp,
+            };
+            av1_rc_layer_info = av1_rc_layer_info
+                .use_min_q_index(true)
+                .min_q_index(q_index)
+                .use_max_q_index(true)
+                .max_q_index(q_index);
+        } else {
+            // In CBR/VBR, let device handle QP
+            av1_rc_layer_info = av1_rc_layer_info
+                .use_min_q_index(false)
+                .use_max_q_index(false);
+        }
 
         let rc_layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
             .average_bitrate(average_bitrate as u64)

--- a/src/encoder/av1/init.rs
+++ b/src/encoder/av1/init.rs
@@ -10,6 +10,7 @@ use crate::encoder::{ColorDescription, PixelFormat};
 use crate::error::{PixelForgeError, Result};
 use crate::vulkan::VideoContext;
 use ash::vk;
+use ash::vk::TaggedStructure;
 use std::ptr;
 use tracing::{debug, info, warn};
 
@@ -69,22 +70,17 @@ impl AV1Encoder {
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_AV1)
             .chroma_subsampling(chroma_subsampling)
             .luma_bit_depth(luma_bit_depth)
-            .chroma_bit_depth(chroma_bit_depth);
-        profile_info.p_next =
-            (&mut av1_profile_info as *mut vk::VideoEncodeAV1ProfileInfoKHR).cast();
+            .chroma_bit_depth(chroma_bit_depth)
+            .push(&mut av1_profile_info);
 
         // Query encode capabilities.
         let video_queue_instance =
             ash::khr::video_queue::Instance::load(context.entry(), context.instance());
         let mut av1_capabilities = vk::VideoEncodeAV1CapabilitiesKHR::default();
-        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR {
-            p_next: (&mut av1_capabilities as *mut vk::VideoEncodeAV1CapabilitiesKHR).cast(),
-            ..Default::default()
-        };
-        let mut capabilities = vk::VideoCapabilitiesKHR {
-            p_next: (&mut encode_capabilities as *mut vk::VideoEncodeCapabilitiesKHR).cast(),
-            ..Default::default()
-        };
+        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR::default();
+        let mut capabilities = vk::VideoCapabilitiesKHR::default()
+            .push(&mut encode_capabilities)
+            .push(&mut av1_capabilities);
 
         let result = unsafe {
             (video_queue_instance
@@ -340,13 +336,14 @@ impl AV1Encoder {
                 vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET
                     | vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN,
             );
-        query_feedback_info.p_next = (&profile_info as *const vk::VideoProfileInfoKHR).cast();
 
-        let mut query_pool_create_info = vk::QueryPoolCreateInfo::default()
-            .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
-            .query_count(1);
-        query_pool_create_info.p_next =
-            (&query_feedback_info as *const vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR).cast();
+        let query_pool_create_info = unsafe {
+            vk::QueryPoolCreateInfo::default()
+                .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
+                .query_count(1)
+                .extend(&mut query_feedback_info)
+                .push(&mut profile_info)
+        };
 
         let query_pool = unsafe {
             context

--- a/src/encoder/av1/init.rs
+++ b/src/encoder/av1/init.rs
@@ -12,7 +12,7 @@ use crate::vulkan::VideoContext;
 use ash::vk;
 use ash::vk::TaggedStructure;
 use std::ptr;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 impl AV1Encoder {
     /// Create a new AV1 encoder.
@@ -28,13 +28,6 @@ impl AV1Encoder {
 
         let width = config.dimensions.width;
         let height = config.dimensions.height;
-
-        warn!(
-            "AV1 encoding is experimental. On NVIDIA GPUs, P-frames cannot reference other \
-             P-frames, causing all P-frames to reference the I-frame instead. This leads to \
-             progressively larger frame sizes over time. Consider using H.264 or HEVC until \
-             this is resolved."
-        );
 
         info!(
             "Creating AV1 encoder: requested {}x{}, pixel_format={:?}",

--- a/src/encoder/av1/init.rs
+++ b/src/encoder/av1/init.rs
@@ -341,8 +341,8 @@ impl AV1Encoder {
             vk::QueryPoolCreateInfo::default()
                 .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
                 .query_count(1)
-                .extend(&mut query_feedback_info)
-                .push(&mut profile_info)
+                .push(&mut query_feedback_info)
+                .extend(&mut profile_info)
         };
 
         let query_pool = unsafe {

--- a/src/encoder/av1/session_params.rs
+++ b/src/encoder/av1/session_params.rs
@@ -3,6 +3,7 @@ use super::AV1Encoder;
 use crate::encoder::{BitDepth, ColorDescription, PixelFormat};
 use crate::error::{PixelForgeError, Result};
 use ash::vk;
+use ash::vk::TaggedStructure;
 use std::ptr;
 
 impl AV1Encoder {
@@ -154,15 +155,10 @@ impl AV1Encoder {
                 .std_operating_points(std::slice::from_ref(&operating_point));
 
         let mut quality_info = vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
-        quality_info.p_next = (&mut av1_session_params_create_info
-            as *mut vk::VideoEncodeAV1SessionParametersCreateInfoKHR)
-            .cast();
-
-        let session_params_create_info = vk::VideoSessionParametersCreateInfoKHR {
-            video_session: self.session,
-            p_next: (&mut quality_info as *mut vk::VideoEncodeQualityLevelInfoKHR).cast(),
-            ..Default::default()
-        };
+        let session_params_create_info = vk::VideoSessionParametersCreateInfoKHR::default()
+            .video_session(self.session)
+            .push(&mut quality_info)
+            .push(&mut av1_session_params_create_info);
 
         let session_params = unsafe {
             self.video_queue_fn

--- a/src/encoder/h264/api.rs
+++ b/src/encoder/h264/api.rs
@@ -6,6 +6,7 @@ use crate::encoder::{ColorDescription, EncodedPacket};
 use crate::error::Result;
 use crate::PixelForgeError;
 use ash::vk;
+use ash::vk::TaggedStructure;
 use tracing::debug;
 
 impl H264Encoder {
@@ -176,24 +177,17 @@ impl H264Encoder {
             .std_sps_id(0)
             .std_pps_id(0);
 
-        let get_info = vk::VideoEncodeSessionParametersGetInfoKHR {
-            video_session_parameters: self.session_params,
-            p_next: (&mut h264_get_info as *mut vk::VideoEncodeH264SessionParametersGetInfoKHR)
-                .cast(),
-            ..Default::default()
-        };
+        let get_info = vk::VideoEncodeSessionParametersGetInfoKHR::default()
+            .video_session_parameters(self.session_params)
+            .push(&mut h264_get_info);
 
         // Some implementations misbehave for a size-only query (pData = NULL), especially with
         // 4:4:4 profiles. vk_video_samples avoids that by providing a preallocated buffer.
         let mut data = vec![0u8; 4096];
         let mut data_size: usize = data.len();
         let mut h264_feedback = vk::VideoEncodeH264SessionParametersFeedbackInfoKHR::default();
-        let mut feedback = vk::VideoEncodeSessionParametersFeedbackInfoKHR {
-            p_next: (&mut h264_feedback
-                as *mut vk::VideoEncodeH264SessionParametersFeedbackInfoKHR)
-                .cast(),
-            ..Default::default()
-        };
+        let mut feedback =
+            vk::VideoEncodeSessionParametersFeedbackInfoKHR::default().push(&mut h264_feedback);
 
         let mut attempts = 0;
         loop {

--- a/src/encoder/h264/encode.rs
+++ b/src/encoder/h264/encode.rs
@@ -7,6 +7,7 @@ use crate::encoder::resources::{
 };
 use crate::error::{PixelForgeError, Result};
 use ash::vk;
+use ash::vk::TaggedStructure;
 use tracing::debug;
 
 impl H264Encoder {
@@ -330,11 +331,12 @@ impl H264Encoder {
             .enumerate()
         {
             let ref_info = &self.l0_references[i];
-            let mut slot = vk::VideoReferenceSlotInfoKHR::default()
-                .slot_index(ref_info.dpb_slot as i32)
-                .picture_resource(resource);
-            slot.p_next = (dpb_info as *mut vk::VideoEncodeH264DpbSlotInfoKHR).cast();
-            l0_slots.push(slot);
+            l0_slots.push(
+                vk::VideoReferenceSlotInfoKHR::default()
+                    .slot_index(ref_info.dpb_slot as i32)
+                    .picture_resource(resource)
+                    .push(dpb_info),
+            );
         }
 
         // 4. Handle Backward Ref (L1) for B-frames
@@ -371,11 +373,12 @@ impl H264Encoder {
         };
 
         let backward_ref_slot = if let Some(ref resource) = backward_resource {
-            let mut slot = vk::VideoReferenceSlotInfoKHR::default()
-                .slot_index(self.backward_reference_dpb_slot as i32)
-                .picture_resource(resource);
-            slot.p_next = (&mut backward_dpb_info as *mut vk::VideoEncodeH264DpbSlotInfoKHR).cast();
-            Some(slot)
+            Some(
+                vk::VideoReferenceSlotInfoKHR::default()
+                    .slot_index(self.backward_reference_dpb_slot as i32)
+                    .picture_resource(resource)
+                    .push(&mut backward_dpb_info),
+            )
         } else {
             None
         };
@@ -399,21 +402,19 @@ impl H264Encoder {
         let mut h264_dpb_slot_info =
             vk::VideoEncodeH264DpbSlotInfoKHR::default().std_reference_info(&std_reference_info);
 
-        let mut setup_reference_slot = vk::VideoReferenceSlotInfoKHR::default()
+        let setup_reference_slot = vk::VideoReferenceSlotInfoKHR::default()
             .slot_index(self.current_dpb_slot as i32)
-            .picture_resource(&setup_picture_resource);
-        setup_reference_slot.p_next =
-            (&mut h264_dpb_slot_info as *mut vk::VideoEncodeH264DpbSlotInfoKHR).cast();
+            .picture_resource(&setup_picture_resource)
+            .push(&mut h264_dpb_slot_info);
 
         // Also create a setup slot for begin_info (slotIndex = -1)
         let mut h264_begin_dpb_slot_info =
             vk::VideoEncodeH264DpbSlotInfoKHR::default().std_reference_info(&std_reference_info);
 
-        let mut setup_slot_for_begin = vk::VideoReferenceSlotInfoKHR::default()
+        let setup_slot_for_begin = vk::VideoReferenceSlotInfoKHR::default()
             .slot_index(-1) // Marked as inactive for begin
-            .picture_resource(&setup_picture_resource);
-        setup_slot_for_begin.p_next =
-            (&mut h264_begin_dpb_slot_info as *mut vk::VideoEncodeH264DpbSlotInfoKHR).cast();
+            .picture_resource(&setup_picture_resource)
+            .push(&mut h264_begin_dpb_slot_info);
 
         // Collect final reference slots for VIDEO ENCODE INFO
         let mut encode_ref_slots = Vec::new();
@@ -441,8 +442,7 @@ impl H264Encoder {
             encode_info = encode_info.reference_slots(&encode_ref_slots);
         }
 
-        encode_info.p_next =
-            (&mut h264_picture_info as *mut vk::VideoEncodeH264PictureInfoKHR).cast();
+        encode_info = encode_info.push(&mut h264_picture_info);
 
         // Collect reference slots for BEGIN VIDEO CODING
         let mut reference_slots_for_begin = vec![setup_slot_for_begin];
@@ -492,13 +492,12 @@ impl H264Encoder {
             .use_max_qp(true)
             .max_qp(max_qp);
 
-        let mut rc_layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
+        let rc_layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
             .average_bitrate(average_bitrate as u64)
             .max_bitrate(max_bitrate as u64)
             .frame_rate_numerator(self.config.frame_rate_numerator)
-            .frame_rate_denominator(self.config.frame_rate_denominator);
-        rc_layer_info.p_next =
-            (&mut h264_rc_layer_info as *mut vk::VideoEncodeH264RateControlLayerInfoKHR).cast();
+            .frame_rate_denominator(self.config.frame_rate_denominator)
+            .push(&mut h264_rc_layer_info);
 
         let rc_layers = [rc_layer_info];
 
@@ -514,7 +513,6 @@ impl H264Encoder {
                 .layers(&rc_layers)
                 .virtual_buffer_size_in_ms(self.config.virtual_buffer_size_ms)
                 .initial_virtual_buffer_size_in_ms(self.config.initial_virtual_buffer_size_ms);
-            rc_info.p_next = &mut h264_rc_info as *mut _ as *mut std::ffi::c_void;
         }
 
         // Begin video coding.
@@ -526,13 +524,14 @@ impl H264Encoder {
                 .video_session(self.session)
                 .video_session_parameters(self.session_params)
                 .reference_slots(&reference_slots_for_begin)
+                .push(&mut h264_rc_info)
         } else {
-            let mut info = vk::VideoBeginCodingInfoKHR::default()
+            vk::VideoBeginCodingInfoKHR::default()
                 .video_session(self.session)
                 .video_session_parameters(self.session_params)
-                .reference_slots(&reference_slots_for_begin);
-            info.p_next = (&mut rc_info as *mut vk::VideoEncodeRateControlInfoKHR).cast();
-            info
+                .reference_slots(&reference_slots_for_begin)
+                .push(&mut h264_rc_info)
+                .push(&mut rc_info)
         };
 
         unsafe {
@@ -548,16 +547,15 @@ impl H264Encoder {
         if is_first_frame {
             let mut quality_level_info =
                 vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
-            quality_level_info.p_next =
-                (&mut rc_info as *mut vk::VideoEncodeRateControlInfoKHR).cast();
 
-            let mut control_info = vk::VideoCodingControlInfoKHR::default().flags(
-                vk::VideoCodingControlFlagsKHR::RESET
-                    | vk::VideoCodingControlFlagsKHR::ENCODE_RATE_CONTROL
-                    | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
-            );
-            control_info.p_next =
-                (&mut quality_level_info as *mut vk::VideoEncodeQualityLevelInfoKHR).cast();
+            let control_info = vk::VideoCodingControlInfoKHR::default()
+                .flags(
+                    vk::VideoCodingControlFlagsKHR::RESET
+                        | vk::VideoCodingControlFlagsKHR::ENCODE_RATE_CONTROL
+                        | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
+                )
+                .push(&mut rc_info)
+                .push(&mut quality_level_info);
 
             unsafe {
                 (self.video_queue_fn.fp().cmd_control_video_coding_khr)(

--- a/src/encoder/h264/encode.rs
+++ b/src/encoder/h264/encode.rs
@@ -555,6 +555,7 @@ impl H264Encoder {
                         | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
                 )
                 .push(&mut rc_info)
+                .push(&mut h264_rc_info)
                 .push(&mut quality_level_info);
 
             unsafe {

--- a/src/encoder/h264/init.rs
+++ b/src/encoder/h264/init.rs
@@ -82,8 +82,8 @@ impl H264Encoder {
         let mut h264_capabilities = vk::VideoEncodeH264CapabilitiesKHR::default();
         let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR::default();
 
-        let h264_capabilities_dbg = h264_capabilities.clone();
-        let encode_capabilities_dbg = encode_capabilities.clone();
+        let h264_capabilities_dbg = h264_capabilities;
+        let encode_capabilities_dbg = encode_capabilities;
 
         let mut capabilities = vk::VideoCapabilitiesKHR::default()
             .push(&mut encode_capabilities)

--- a/src/encoder/h264/init.rs
+++ b/src/encoder/h264/init.rs
@@ -13,6 +13,7 @@ use crate::encoder::PixelFormat;
 use crate::error::{PixelForgeError, Result};
 use crate::vulkan::VideoContext;
 use ash::vk;
+use ash::vk::TaggedStructure;
 use std::ptr;
 use tracing::{debug, info};
 
@@ -66,13 +67,12 @@ impl H264Encoder {
         let mut h264_profile_info =
             vk::VideoEncodeH264ProfileInfoKHR::default().std_profile_idc(profile_idc);
 
-        let mut profile_info = vk::VideoProfileInfoKHR::default()
+        let profile_info = vk::VideoProfileInfoKHR::default()
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H264)
             .chroma_subsampling(chroma_subsampling)
             .luma_bit_depth(luma_bit_depth)
-            .chroma_bit_depth(chroma_bit_depth);
-        profile_info.p_next =
-            (&mut h264_profile_info as *mut vk::VideoEncodeH264ProfileInfoKHR).cast();
+            .chroma_bit_depth(chroma_bit_depth)
+            .push(&mut h264_profile_info);
 
         // Query encode capabilities for the selected profile and use them to derive a safe
         // coded extent and DPB limits. This mirrors vk_video_samples and avoids device loss
@@ -80,14 +80,14 @@ impl H264Encoder {
         let video_queue_instance =
             ash::khr::video_queue::Instance::load(context.entry(), context.instance());
         let mut h264_capabilities = vk::VideoEncodeH264CapabilitiesKHR::default();
-        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR {
-            p_next: (&mut h264_capabilities as *mut vk::VideoEncodeH264CapabilitiesKHR).cast(),
-            ..Default::default()
-        };
-        let mut capabilities = vk::VideoCapabilitiesKHR {
-            p_next: (&mut encode_capabilities as *mut vk::VideoEncodeCapabilitiesKHR).cast(),
-            ..Default::default()
-        };
+        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR::default();
+
+        let h264_capabilities_dbg = h264_capabilities.clone();
+        let encode_capabilities_dbg = encode_capabilities.clone();
+
+        let mut capabilities = vk::VideoCapabilitiesKHR::default()
+            .push(&mut encode_capabilities)
+            .push(&mut h264_capabilities);
 
         let result = unsafe {
             (video_queue_instance
@@ -107,22 +107,22 @@ impl H264Encoder {
 
         debug!(
             "H.264 capabilities: maxLevelIdc={}, maxSliceCount={}, maxPPictureL0ReferenceCount={}, maxBPictureL0ReferenceCount={}, maxL1ReferenceCount={}, maxTemporalLayerCount={}, prefersGopRemainingFrames={}, requiresGopRemainingFrames={}, stdSyntaxFlags={:#010x}",
-            h264_capabilities.max_level_idc,
-            h264_capabilities.max_slice_count,
-            h264_capabilities.max_p_picture_l0_reference_count,
-            h264_capabilities.max_b_picture_l0_reference_count,
-            h264_capabilities.max_l1_reference_count,
-            h264_capabilities.max_temporal_layer_count,
-            h264_capabilities.prefers_gop_remaining_frames,
-            h264_capabilities.requires_gop_remaining_frames,
-            h264_capabilities.std_syntax_flags.as_raw(),
+            h264_capabilities_dbg.max_level_idc,
+            h264_capabilities_dbg.max_slice_count,
+            h264_capabilities_dbg.max_p_picture_l0_reference_count,
+            h264_capabilities_dbg.max_b_picture_l0_reference_count,
+            h264_capabilities_dbg.max_l1_reference_count,
+            h264_capabilities_dbg.max_temporal_layer_count,
+            h264_capabilities_dbg.prefers_gop_remaining_frames,
+            h264_capabilities_dbg.requires_gop_remaining_frames,
+            h264_capabilities_dbg.std_syntax_flags.as_raw(),
         );
         debug!(
             "Encode capabilities: encodeInputPictureGranularity={}x{}, supportedEncodeFeedbackFlags={:#010x}, maxQualityLevels={}",
-            encode_capabilities.encode_input_picture_granularity.width,
-            encode_capabilities.encode_input_picture_granularity.height,
-            encode_capabilities.supported_encode_feedback_flags.as_raw(),
-            encode_capabilities.max_quality_levels,
+            encode_capabilities_dbg.encode_input_picture_granularity.width,
+            encode_capabilities_dbg.encode_input_picture_granularity.height,
+            encode_capabilities_dbg.supported_encode_feedback_flags.as_raw(),
+            encode_capabilities_dbg.max_quality_levels,
         );
         debug!(
             "Video capabilities: flags={:#010x}, minBitstreamBufferOffsetAlignment={}, minBitstreamBufferSizeAlignment={}, minCodedExtent={}x{}, maxCodedExtent={}x{}, maxDpbSlots={}, maxActiveReferencePictures={}, pictureAccessGranularity={}x{}",
@@ -144,12 +144,8 @@ impl H264Encoder {
             ash::khr::video_encode_queue::Instance::load(context.entry(), context.instance());
         let mut h264_quality_level_properties =
             vk::VideoEncodeH264QualityLevelPropertiesKHR::default();
-        let mut quality_level_properties = vk::VideoEncodeQualityLevelPropertiesKHR {
-            p_next: (&mut h264_quality_level_properties
-                as *mut vk::VideoEncodeH264QualityLevelPropertiesKHR)
-                .cast(),
-            ..Default::default()
-        };
+        let mut quality_level_properties = vk::VideoEncodeQualityLevelPropertiesKHR::default()
+            .push(&mut h264_quality_level_properties);
         let quality_level_info = vk::PhysicalDeviceVideoEncodeQualityLevelInfoKHR::default()
             .video_profile(&profile_info)
             .quality_level(0);
@@ -410,13 +406,12 @@ impl H264Encoder {
         // Create profile info for images/buffers.
         let mut h264_profile_for_resources =
             vk::VideoEncodeH264ProfileInfoKHR::default().std_profile_idc(profile_idc);
-        let mut profile_for_resources = vk::VideoProfileInfoKHR::default()
+        let profile_for_resources = vk::VideoProfileInfoKHR::default()
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H264)
             .chroma_subsampling(chroma_subsampling)
             .luma_bit_depth(luma_bit_depth)
-            .chroma_bit_depth(chroma_bit_depth);
-        profile_for_resources.p_next =
-            (&mut h264_profile_for_resources as *mut vk::VideoEncodeH264ProfileInfoKHR).cast();
+            .chroma_bit_depth(chroma_bit_depth)
+            .push(&mut h264_profile_for_resources);
 
         // Create input image.
         let (input_image, input_image_memory, input_image_view) = create_image(
@@ -494,9 +489,8 @@ impl H264Encoder {
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H264)
             .chroma_subsampling(chroma_subsampling)
             .luma_bit_depth(luma_bit_depth)
-            .chroma_bit_depth(chroma_bit_depth);
-        profile_info_query.p_next =
-            (&mut h264_profile_info_query as *mut vk::VideoEncodeH264ProfileInfoKHR).cast();
+            .chroma_bit_depth(chroma_bit_depth)
+            .push(&mut h264_profile_info_query);
 
         let mut encode_feedback_create = vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR::default()
             .encode_feedback_flags(
@@ -504,15 +498,13 @@ impl H264Encoder {
                     | vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN,
             );
 
-        encode_feedback_create.p_next =
-            (&mut profile_info_query as *mut vk::VideoProfileInfoKHR).cast();
-
-        let mut query_pool_create_info = vk::QueryPoolCreateInfo::default()
-            .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
-            .query_count(1);
-        query_pool_create_info.p_next = (&mut encode_feedback_create
-            as *mut vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR)
-            .cast();
+        let query_pool_create_info = unsafe {
+            vk::QueryPoolCreateInfo::default()
+                .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
+                .query_count(1)
+                .extend(&mut profile_info_query)
+                .push(&mut encode_feedback_create)
+        };
 
         let query_pool = unsafe {
             context

--- a/src/encoder/h264/session_params.rs
+++ b/src/encoder/h264/session_params.rs
@@ -3,6 +3,7 @@ use super::H264Encoder;
 use crate::encoder::{BitDepth, ColorDescription, PixelFormat};
 use crate::error::{PixelForgeError, Result};
 use ash::vk;
+use ash::vk::TaggedStructure;
 use std::ptr;
 
 impl H264Encoder {
@@ -180,14 +181,11 @@ impl H264Encoder {
         // Chain quality level info into session parameters creation.
         // This is required by AMD RADV and matches FFmpeg's approach.
         let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
-        quality_level_info.p_next = (&mut h264_params_create_info
-            as *mut vk::VideoEncodeH264SessionParametersCreateInfoKHR)
-            .cast();
 
-        let mut params_create_info =
-            vk::VideoSessionParametersCreateInfoKHR::default().video_session(self.session);
-        params_create_info.p_next =
-            (&mut quality_level_info as *mut vk::VideoEncodeQualityLevelInfoKHR).cast();
+        let params_create_info = vk::VideoSessionParametersCreateInfoKHR::default()
+            .video_session(self.session)
+            .push(&mut h264_params_create_info)
+            .push(&mut quality_level_info);
 
         let mut session_params = vk::VideoSessionParametersKHR::null();
         let result = unsafe {

--- a/src/encoder/h265/api.rs
+++ b/src/encoder/h265/api.rs
@@ -6,6 +6,7 @@ use crate::encoder::{ColorDescription, EncodedPacket};
 use crate::error::Result;
 use crate::PixelForgeError;
 use ash::vk;
+use ash::vk::TaggedStructure;
 use tracing::debug;
 
 impl H265Encoder {
@@ -212,24 +213,17 @@ impl H265Encoder {
             .std_sps_id(0)
             .std_pps_id(0);
 
-        let get_info = vk::VideoEncodeSessionParametersGetInfoKHR {
-            video_session_parameters: self.session_params,
-            p_next: (&mut h265_get_info as *mut vk::VideoEncodeH265SessionParametersGetInfoKHR)
-                .cast(),
-            ..Default::default()
-        };
+        let get_info = vk::VideoEncodeSessionParametersGetInfoKHR::default()
+            .video_session_parameters(self.session_params)
+            .push(&mut h265_get_info);
 
         // Some implementations misbehave for a size-only query (pData = NULL). Use a
         // preallocated buffer and retry on INCOMPLETE (vk_video_samples-style).
         let mut data = vec![0u8; 4096];
         let mut data_size: usize = data.len();
         let mut h265_feedback = vk::VideoEncodeH265SessionParametersFeedbackInfoKHR::default();
-        let mut feedback = vk::VideoEncodeSessionParametersFeedbackInfoKHR {
-            p_next: (&mut h265_feedback
-                as *mut vk::VideoEncodeH265SessionParametersFeedbackInfoKHR)
-                .cast(),
-            ..Default::default()
-        };
+        let mut feedback =
+            vk::VideoEncodeSessionParametersFeedbackInfoKHR::default().push(&mut h265_feedback);
 
         let mut attempts = 0;
         loop {

--- a/src/encoder/h265/encode.rs
+++ b/src/encoder/h265/encode.rs
@@ -447,27 +447,29 @@ impl H265Encoder {
 
         if has_l0_ref {
             for ref_info in &self.l0_references {
-                let h265_slot_info = slot_infos_iter.next().unwrap();
+                if let Some(h265_slot_info) = slot_infos_iter.next() {
+                    let ref_slot = vk::VideoReferenceSlotInfoKHR::default()
+                        .slot_index(ref_info.dpb_slot as i32)
+                        .picture_resource(&ref_resources[stored_indices_count])
+                        .push(h265_slot_info);
+
+                    reference_slots.push(ref_slot);
+                    reference_slots_for_begin.push(ref_slot);
+                    stored_indices_count += 1;
+                }
+            }
+        }
+
+        if has_l1_ref {
+            if let Some(h265_slot_info) = slot_infos_iter.next() {
                 let ref_slot = vk::VideoReferenceSlotInfoKHR::default()
-                    .slot_index(ref_info.dpb_slot as i32)
+                    .slot_index(self.backward_reference_dpb_slot as i32)
                     .picture_resource(&ref_resources[stored_indices_count])
                     .push(h265_slot_info);
 
                 reference_slots.push(ref_slot);
                 reference_slots_for_begin.push(ref_slot);
-                stored_indices_count += 1;
             }
-        }
-
-        if has_l1_ref {
-            let h265_slot_info = slot_infos_iter.next().unwrap();
-            let ref_slot = vk::VideoReferenceSlotInfoKHR::default()
-                .slot_index(self.backward_reference_dpb_slot as i32)
-                .picture_resource(&ref_resources[stored_indices_count])
-                .push(h265_slot_info);
-
-            reference_slots.push(ref_slot);
-            reference_slots_for_begin.push(ref_slot);
         }
 
         // Rate control setup.

--- a/src/encoder/h265/encode.rs
+++ b/src/encoder/h265/encode.rs
@@ -583,6 +583,7 @@ impl H265Encoder {
                         | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
                 )
                 .push(&mut rc_info)
+                .push(&mut h265_rc_info)
                 .push(&mut quality_level_info);
 
             unsafe {

--- a/src/encoder/h265/encode.rs
+++ b/src/encoder/h265/encode.rs
@@ -11,6 +11,7 @@ use crate::encoder::resources::{
 };
 use crate::error::{PixelForgeError, Result};
 use ash::vk;
+use ash::vk::TaggedStructure;
 use tracing::debug;
 
 impl H265Encoder {
@@ -356,22 +357,20 @@ impl H265Encoder {
         let mut h265_setup_dpb_slot_info =
             vk::VideoEncodeH265DpbSlotInfoKHR::default().std_reference_info(&std_reference_info);
 
-        let mut setup_slot_info = vk::VideoReferenceSlotInfoKHR::default()
+        let setup_slot_info = vk::VideoReferenceSlotInfoKHR::default()
             .slot_index(self.current_dpb_slot as i32)
-            .picture_resource(&setup_picture_resource);
-        setup_slot_info.p_next =
-            (&mut h265_setup_dpb_slot_info as *mut vk::VideoEncodeH265DpbSlotInfoKHR).cast();
+            .picture_resource(&setup_picture_resource)
+            .push(&mut h265_setup_dpb_slot_info);
 
         // Setup slot for begin - always use -1 to indicate it's not yet active.
         // (it will be written to during encoding)
         let mut h265_begin_dpb_slot_info =
             vk::VideoEncodeH265DpbSlotInfoKHR::default().std_reference_info(&std_reference_info);
 
-        let mut setup_slot_for_begin = vk::VideoReferenceSlotInfoKHR::default()
+        let setup_slot_for_begin = vk::VideoReferenceSlotInfoKHR::default()
             .slot_index(-1) // Always -1 for setup slot
-            .picture_resource(&setup_picture_resource);
-        setup_slot_for_begin.p_next =
-            (&mut h265_begin_dpb_slot_info as *mut vk::VideoEncodeH265DpbSlotInfoKHR).cast();
+            .picture_resource(&setup_picture_resource)
+            .push(&mut h265_begin_dpb_slot_info);
 
         // Set up reference slots.
 
@@ -444,36 +443,31 @@ impl H265Encoder {
         // Re-construct the list of DPB slots to assign correct slot_index.
 
         let mut stored_indices_count = 0;
+        let mut slot_infos_iter = h265_slot_infos.iter_mut();
+
         if has_l0_ref {
             for ref_info in &self.l0_references {
-                let mut ref_slot = vk::VideoReferenceSlotInfoKHR::default()
+                let h265_slot_info = slot_infos_iter.next().unwrap();
+                let ref_slot = vk::VideoReferenceSlotInfoKHR::default()
                     .slot_index(ref_info.dpb_slot as i32)
-                    .picture_resource(&ref_resources[stored_indices_count]);
-
-                ref_slot.p_next = (&mut h265_slot_infos[stored_indices_count]
-                    as *mut vk::VideoEncodeH265DpbSlotInfoKHR)
-                    .cast();
+                    .picture_resource(&ref_resources[stored_indices_count])
+                    .push(h265_slot_info);
 
                 reference_slots.push(ref_slot);
                 reference_slots_for_begin.push(ref_slot);
-
                 stored_indices_count += 1;
             }
         }
 
         if has_l1_ref {
-            let mut ref_slot = vk::VideoReferenceSlotInfoKHR::default()
+            let h265_slot_info = slot_infos_iter.next().unwrap();
+            let ref_slot = vk::VideoReferenceSlotInfoKHR::default()
                 .slot_index(self.backward_reference_dpb_slot as i32)
-                .picture_resource(&ref_resources[stored_indices_count]);
-
-            ref_slot.p_next = (&mut h265_slot_infos[stored_indices_count]
-                as *mut vk::VideoEncodeH265DpbSlotInfoKHR)
-                .cast();
+                .picture_resource(&ref_resources[stored_indices_count])
+                .push(h265_slot_info);
 
             reference_slots.push(ref_slot);
             reference_slots_for_begin.push(ref_slot);
-
-            // stored_indices_count += 1; // Not needed anymore
         }
 
         // Rate control setup.
@@ -525,13 +519,12 @@ impl H265Encoder {
             .min_qp(min_qp)
             .max_qp(max_qp);
 
-        let mut rc_layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
+        let rc_layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
             .average_bitrate(average_bitrate as u64)
             .max_bitrate(max_bitrate as u64)
             .frame_rate_numerator(self.config.frame_rate_numerator)
-            .frame_rate_denominator(self.config.frame_rate_denominator);
-        rc_layer_info.p_next =
-            (&mut h265_rc_layer_info as *mut vk::VideoEncodeH265RateControlLayerInfoKHR).cast();
+            .frame_rate_denominator(self.config.frame_rate_denominator)
+            .push(&mut h265_rc_layer_info);
 
         let rc_layers = [rc_layer_info];
 
@@ -547,8 +540,6 @@ impl H265Encoder {
                 .layers(&rc_layers)
                 .virtual_buffer_size_in_ms(self.config.virtual_buffer_size_ms)
                 .initial_virtual_buffer_size_in_ms(self.config.initial_virtual_buffer_size_ms);
-            rc_info.p_next =
-                (&mut h265_rc_info as *mut vk::VideoEncodeH265RateControlInfoKHR).cast();
         }
 
         // Begin video coding.
@@ -559,13 +550,14 @@ impl H265Encoder {
                 .video_session(self.session)
                 .video_session_parameters(self.session_params)
                 .reference_slots(&reference_slots_for_begin)
+                .push(&mut h265_rc_info)
         } else {
-            let mut info = vk::VideoBeginCodingInfoKHR::default()
+            vk::VideoBeginCodingInfoKHR::default()
                 .video_session(self.session)
                 .video_session_parameters(self.session_params)
-                .reference_slots(&reference_slots_for_begin);
-            info.p_next = (&mut rc_info as *mut vk::VideoEncodeRateControlInfoKHR).cast();
-            info
+                .reference_slots(&reference_slots_for_begin)
+                .push(&mut h265_rc_info)
+                .push(&mut rc_info)
         };
 
         unsafe {
@@ -581,16 +573,15 @@ impl H265Encoder {
         if is_first_frame {
             let mut quality_level_info =
                 vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
-            quality_level_info.p_next =
-                (&mut rc_info as *mut vk::VideoEncodeRateControlInfoKHR).cast();
 
-            let mut control_info = vk::VideoCodingControlInfoKHR::default().flags(
-                vk::VideoCodingControlFlagsKHR::RESET
-                    | vk::VideoCodingControlFlagsKHR::ENCODE_RATE_CONTROL
-                    | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
-            );
-            control_info.p_next =
-                (&mut quality_level_info as *mut vk::VideoEncodeQualityLevelInfoKHR).cast();
+            let control_info = vk::VideoCodingControlInfoKHR::default()
+                .flags(
+                    vk::VideoCodingControlFlagsKHR::RESET
+                        | vk::VideoCodingControlFlagsKHR::ENCODE_RATE_CONTROL
+                        | vk::VideoCodingControlFlagsKHR::ENCODE_QUALITY_LEVEL,
+                )
+                .push(&mut rc_info)
+                .push(&mut quality_level_info);
 
             unsafe {
                 (self.video_queue_fn.fp().cmd_control_video_coding_khr)(
@@ -601,16 +592,15 @@ impl H265Encoder {
         }
 
         // Encode command.
-        let mut encode_info = vk::VideoEncodeInfoKHR::default()
+        let encode_info = vk::VideoEncodeInfoKHR::default()
             .flags(vk::VideoEncodeFlagsKHR::empty())
             .src_picture_resource(src_picture_resource)
             .setup_reference_slot(&setup_slot_info)
             .reference_slots(&reference_slots)
             .dst_buffer(self.bitstream_buffer)
             .dst_buffer_offset(0)
-            .dst_buffer_range(MIN_BITSTREAM_BUFFER_SIZE as u64);
-        encode_info.p_next =
-            (&mut h265_picture_info as *mut vk::VideoEncodeH265PictureInfoKHR).cast();
+            .dst_buffer_range(MIN_BITSTREAM_BUFFER_SIZE as u64)
+            .push(&mut h265_picture_info);
 
         unsafe {
             self.context.device().cmd_begin_query(

--- a/src/encoder/h265/init.rs
+++ b/src/encoder/h265/init.rs
@@ -12,6 +12,7 @@ use crate::encoder::{BitDepth, ColorDescription, PixelFormat};
 use crate::error::{PixelForgeError, Result};
 use crate::vulkan::VideoContext;
 use ash::vk;
+use ash::vk::TaggedStructure;
 use std::ptr;
 use tracing::{debug, info};
 
@@ -78,26 +79,21 @@ impl H265Encoder {
         let mut h265_profile_info =
             vk::VideoEncodeH265ProfileInfoKHR::default().std_profile_idc(profile_idc);
 
-        let mut profile_info = vk::VideoProfileInfoKHR::default()
+        let profile_info = vk::VideoProfileInfoKHR::default()
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H265)
             .chroma_subsampling(chroma_subsampling)
             .luma_bit_depth(bit_depth_flags)
-            .chroma_bit_depth(bit_depth_flags);
-        profile_info.p_next =
-            (&mut h265_profile_info as *mut vk::VideoEncodeH265ProfileInfoKHR).cast();
+            .chroma_bit_depth(bit_depth_flags)
+            .push(&mut h265_profile_info);
 
         // Query capabilities to determine limits.
         let video_queue_instance =
             ash::khr::video_queue::Instance::load(context.entry(), context.instance());
         let mut h265_capabilities = vk::VideoEncodeH265CapabilitiesKHR::default();
-        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR {
-            p_next: (&mut h265_capabilities as *mut vk::VideoEncodeH265CapabilitiesKHR).cast(),
-            ..Default::default()
-        };
-        let mut capabilities = vk::VideoCapabilitiesKHR {
-            p_next: (&mut encode_capabilities as *mut vk::VideoEncodeCapabilitiesKHR).cast(),
-            ..Default::default()
-        };
+        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR::default();
+        let mut capabilities = vk::VideoCapabilitiesKHR::default()
+            .push(&mut h265_capabilities)
+            .push(&mut encode_capabilities);
 
         let result = unsafe {
             (video_queue_instance
@@ -305,13 +301,12 @@ impl H265Encoder {
         // Create profile info for images/buffers
         let mut h265_profile_for_resources =
             vk::VideoEncodeH265ProfileInfoKHR::default().std_profile_idc(profile_idc);
-        let mut profile_for_resources = vk::VideoProfileInfoKHR::default()
+        let profile_for_resources = vk::VideoProfileInfoKHR::default()
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H265)
             .chroma_subsampling(chroma_subsampling)
             .luma_bit_depth(bit_depth_flags)
-            .chroma_bit_depth(bit_depth_flags);
-        profile_for_resources.p_next =
-            (&mut h265_profile_for_resources as *mut vk::VideoEncodeH265ProfileInfoKHR).cast();
+            .chroma_bit_depth(bit_depth_flags)
+            .push(&mut h265_profile_for_resources);
 
         // Create input image
         let (input_image, input_image_memory, input_image_view) = create_image(
@@ -389,9 +384,8 @@ impl H265Encoder {
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H265)
             .chroma_subsampling(chroma_subsampling)
             .luma_bit_depth(bit_depth_flags)
-            .chroma_bit_depth(bit_depth_flags);
-        profile_info_query.p_next =
-            (&mut h265_profile_info_query as *mut vk::VideoEncodeH265ProfileInfoKHR).cast();
+            .chroma_bit_depth(bit_depth_flags)
+            .push(&mut h265_profile_info_query);
 
         let mut encode_feedback_create = vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR::default()
             .encode_feedback_flags(
@@ -399,15 +393,13 @@ impl H265Encoder {
                     | vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN,
             );
 
-        encode_feedback_create.p_next =
-            (&mut profile_info_query as *mut vk::VideoProfileInfoKHR).cast();
-
-        let mut query_pool_create_info = vk::QueryPoolCreateInfo::default()
-            .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
-            .query_count(1);
-        query_pool_create_info.p_next = (&mut encode_feedback_create
-            as *mut vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR)
-            .cast();
+        let query_pool_create_info = unsafe {
+            vk::QueryPoolCreateInfo::default()
+                .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
+                .query_count(1)
+                .extend(&mut profile_info_query)
+                .push(&mut encode_feedback_create)
+        };
 
         let query_pool = unsafe {
             context

--- a/src/encoder/h265/session_params.rs
+++ b/src/encoder/h265/session_params.rs
@@ -3,6 +3,7 @@ use super::H265Encoder;
 use crate::encoder::{BitDepth, ColorDescription, PixelFormat};
 use crate::error::{PixelForgeError, Result};
 use ash::vk;
+use ash::vk::TaggedStructure;
 use std::ptr;
 
 impl H265Encoder {
@@ -333,14 +334,11 @@ impl H265Encoder {
                 .parameters_add_info(&h265_add_info);
 
         let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
-        quality_level_info.p_next = (&mut h265_params_create_info
-            as *mut vk::VideoEncodeH265SessionParametersCreateInfoKHR)
-            .cast();
 
-        let mut params_create_info =
-            vk::VideoSessionParametersCreateInfoKHR::default().video_session(self.session);
-        params_create_info.p_next =
-            (&mut quality_level_info as *mut vk::VideoEncodeQualityLevelInfoKHR).cast();
+        let params_create_info = vk::VideoSessionParametersCreateInfoKHR::default()
+            .video_session(self.session)
+            .push(&mut h265_params_create_info)
+            .push(&mut quality_level_info);
 
         let mut session_params = vk::VideoSessionParametersKHR::null();
         let result = unsafe {

--- a/src/encoder/resources.rs
+++ b/src/encoder/resources.rs
@@ -2,6 +2,7 @@ use crate::encoder::{BitDepth, PixelFormat};
 use crate::error::{PixelForgeError, Result};
 use crate::vulkan::VideoContext;
 use ash::vk;
+use ash::vk::TaggedStructure;
 use std::ptr;
 
 /// Minimum bitstream buffer size.
@@ -46,8 +47,9 @@ pub(crate) fn query_supported_video_formats(
     let profiles = [*profile_info];
     let mut profile_list = vk::VideoProfileListInfoKHR::default().profiles(&profiles);
 
-    let mut format_info = vk::PhysicalDeviceVideoFormatInfoKHR::default().image_usage(image_usage);
-    format_info.p_next = (&mut profile_list as *mut vk::VideoProfileListInfoKHR).cast();
+    let format_info = vk::PhysicalDeviceVideoFormatInfoKHR::default()
+        .image_usage(image_usage)
+        .push(&mut profile_list);
 
     let physical_device = context.physical_device();
     let mut count = 0u32;
@@ -170,10 +172,10 @@ pub(crate) fn create_buffer_with_device_address(
 
     let mut alloc_flags_info =
         vk::MemoryAllocateFlagsInfo::default().flags(vk::MemoryAllocateFlags::DEVICE_ADDRESS);
-    let mut alloc_info = vk::MemoryAllocateInfo::default()
+    let alloc_info = vk::MemoryAllocateInfo::default()
         .allocation_size(mem_requirements.size)
-        .memory_type_index(memory_type_index);
-    alloc_info.p_next = &mut alloc_flags_info as *mut _ as *mut _;
+        .memory_type_index(memory_type_index)
+        .push(&mut alloc_flags_info);
 
     let memory = match unsafe { device.allocate_memory(&alloc_info, None) } {
         Ok(m) => m,
@@ -216,11 +218,11 @@ pub(crate) fn create_bitstream_buffer(
     let profiles = [*profile_info];
     let mut profile_list = vk::VideoProfileListInfoKHR::default().profiles(&profiles);
 
-    let mut create_info = vk::BufferCreateInfo::default()
+    let create_info = vk::BufferCreateInfo::default()
         .size(size as vk::DeviceSize)
         .usage(vk::BufferUsageFlags::VIDEO_ENCODE_DST_KHR)
-        .sharing_mode(vk::SharingMode::EXCLUSIVE);
-    create_info.p_next = (&mut profile_list as *mut vk::VideoProfileListInfoKHR).cast();
+        .sharing_mode(vk::SharingMode::EXCLUSIVE)
+        .push(&mut profile_list);
 
     let buffer = unsafe { context.device().create_buffer(&create_info, None) }
         .map_err(|e| PixelForgeError::ResourceCreation(format!("buffer creation: {}", e)))?;
@@ -306,7 +308,7 @@ pub(crate) fn create_image(
     let profiles = [*profile_info];
     let mut profile_list = vk::VideoProfileListInfoKHR::default().profiles(&profiles);
 
-    let mut create_info = vk::ImageCreateInfo::default()
+    let create_info = vk::ImageCreateInfo::default()
         .image_type(vk::ImageType::TYPE_2D)
         .format(format)
         .extent(vk::Extent3D {
@@ -321,8 +323,8 @@ pub(crate) fn create_image(
         .usage(usage)
         .sharing_mode(sharing_mode)
         .queue_family_indices(&queue_families)
-        .initial_layout(vk::ImageLayout::UNDEFINED);
-    create_info.p_next = (&mut profile_list as *mut vk::VideoProfileListInfoKHR).cast();
+        .initial_layout(vk::ImageLayout::UNDEFINED)
+        .push(&mut profile_list);
 
     let image = unsafe { context.device().create_image(&create_info, None) }
         .map_err(|e| PixelForgeError::ResourceCreation(format!("image creation: {}", e)))?;
@@ -591,7 +593,7 @@ pub(crate) fn create_dpb_images(
         let profiles = [*profile_info];
         let mut profile_list = vk::VideoProfileListInfoKHR::default().profiles(&profiles);
 
-        let mut create_info = vk::ImageCreateInfo::default()
+        let create_info = vk::ImageCreateInfo::default()
             .image_type(vk::ImageType::TYPE_2D)
             .format(format)
             .extent(vk::Extent3D {
@@ -605,8 +607,8 @@ pub(crate) fn create_dpb_images(
             .tiling(vk::ImageTiling::OPTIMAL)
             .usage(vk::ImageUsageFlags::VIDEO_ENCODE_DPB_KHR)
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
-            .initial_layout(vk::ImageLayout::UNDEFINED);
-        create_info.p_next = (&mut profile_list as *mut vk::VideoProfileListInfoKHR).cast();
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .push(&mut profile_list);
 
         let image = unsafe { context.device().create_image(&create_info, None) }
             .map_err(|e| PixelForgeError::ResourceCreation(format!("layered DPB image: {}", e)))?;

--- a/src/vulkan.rs
+++ b/src/vulkan.rs
@@ -2,6 +2,7 @@
 use crate::encoder::Codec;
 use crate::error::{PixelForgeError, Result};
 use ash::vk;
+use ash::vk::TaggedStructure;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use tracing::{debug, info, warn};
@@ -471,31 +472,13 @@ impl VideoContext {
         let mut av1_encode_features =
             vk::PhysicalDeviceVideoEncodeAV1FeaturesKHR::default().video_encode_av1(true);
 
-        if supported_encode_codecs.contains(&Codec::AV1) {
-            ycbcr_2plane_444_features.p_next = (&mut av1_encode_features
-                as *mut vk::PhysicalDeviceVideoEncodeAV1FeaturesKHR)
-                .cast();
-        }
-
-        // Chain: sync2_features -> ycbcr_features -> ycbcr_2plane_444_features (-> av1 if supported)
-        ycbcr_features.p_next = (&mut ycbcr_2plane_444_features
-            as *mut vk::PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT)
-            .cast();
-        sync2_features.p_next =
-            (&mut ycbcr_features as *mut vk::PhysicalDeviceSamplerYcbcrConversionFeatures).cast();
-
         // Query descriptor buffer and buffer device address feature support.
         let mut desc_buf_features = vk::PhysicalDeviceDescriptorBufferFeaturesEXT::default();
         let mut buffer_device_address_features =
             vk::PhysicalDeviceBufferDeviceAddressFeatures::default();
 
         if has_descriptor_buffer_ext {
-            let mut feat2 = vk::PhysicalDeviceFeatures2 {
-                p_next: (&mut desc_buf_features
-                    as *mut vk::PhysicalDeviceDescriptorBufferFeaturesEXT)
-                    .cast(),
-                ..Default::default()
-            };
+            let mut feat2 = vk::PhysicalDeviceFeatures2::default().push(&mut desc_buf_features);
             unsafe {
                 instance.get_physical_device_features2(physical_device, &mut feat2);
             }
@@ -503,12 +486,8 @@ impl VideoContext {
                 && desc_buf_features.descriptor_buffer_capture_replay != 0;
 
             // Query buffer device address support.
-            let mut feat2_bda = vk::PhysicalDeviceFeatures2 {
-                p_next: (&mut buffer_device_address_features
-                    as *mut vk::PhysicalDeviceBufferDeviceAddressFeatures)
-                    .cast(),
-                ..Default::default()
-            };
+            let mut feat2_bda =
+                vk::PhysicalDeviceFeatures2::default().push(&mut buffer_device_address_features);
             unsafe {
                 instance.get_physical_device_features2(physical_device, &mut feat2_bda);
             }
@@ -519,16 +498,6 @@ impl VideoContext {
             } else if desc_buf_supported {
                 warn!("VK_EXT_descriptor_buffer extension present but bufferDeviceAddress not supported; descriptor buffer will not be enabled");
             }
-        }
-
-        // Build the feature chain: desc_buf_features -> buffer_device_address_features -> sync2_features -> ...
-        // Only chain desc_buf_features if the extension was available.
-        if has_descriptor_buffer_ext {
-            buffer_device_address_features.p_next =
-                (&mut sync2_features as *mut vk::PhysicalDeviceSynchronization2Features).cast();
-            desc_buf_features.p_next = (&mut buffer_device_address_features
-                as *mut vk::PhysicalDeviceBufferDeviceAddressFeatures)
-                .cast();
         }
 
         // Store whether descriptor buffer is available for use by callers.
@@ -545,17 +514,22 @@ impl VideoContext {
 
         let mut device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
-            .enabled_extension_names(&extension_names);
+            .enabled_extension_names(&extension_names)
+            .push(&mut sync2_features);
 
         // Attach the chain to device_create_info.
         // When descriptor buffer is available, the chain is:
         //   desc_buf_features -> buffer_device_address_features -> sync2_features -> ...
         // When descriptor buffer is not available, only sync2_features is chained.
-        device_create_info.p_next = if has_descriptor_buffer_ext {
-            (&mut desc_buf_features as *mut vk::PhysicalDeviceDescriptorBufferFeaturesEXT).cast()
-        } else {
-            (&mut sync2_features as *mut vk::PhysicalDeviceSynchronization2Features).cast()
-        };
+        if has_descriptor_buffer_ext {
+            device_create_info = device_create_info.push(&mut desc_buf_features);
+            if supported_encode_codecs.contains(&Codec::AV1) {
+                device_create_info = device_create_info.push(&mut av1_encode_features);
+            }
+            device_create_info = device_create_info
+                .push(&mut ycbcr_features)
+                .push(&mut ycbcr_2plane_444_features);
+        }
 
         let device = unsafe { instance.create_device(physical_device, &device_create_info, None) }
             .map_err(|e| PixelForgeError::DeviceCreation(e.to_string()))?;
@@ -608,25 +582,19 @@ impl VideoContext {
         );
 
         // Create video profile info for H.264 encode with typical 8-bit 4:2:0.
-        let mut profile_info = vk::VideoProfileInfoKHR::default()
+        let profile_info = vk::VideoProfileInfoKHR::default()
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H264)
             .chroma_subsampling(vk::VideoChromaSubsamplingFlagsKHR::TYPE_420)
             .luma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8)
-            .chroma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8);
-
-        // Chain the codec-specific profile into profile_info.
-        profile_info.p_next = (&mut h264_profile as *mut vk::VideoEncodeH264ProfileInfoKHR).cast();
+            .chroma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8)
+            .push(&mut h264_profile);
 
         // Create capabilities structures.
         let mut h264_capabilities = vk::VideoEncodeH264CapabilitiesKHR::default();
-        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR {
-            p_next: &mut h264_capabilities as *mut vk::VideoEncodeH264CapabilitiesKHR as *mut _,
-            ..Default::default()
-        };
-        let mut capabilities = vk::VideoCapabilitiesKHR {
-            p_next: &mut encode_capabilities as *mut vk::VideoEncodeCapabilitiesKHR as *mut _,
-            ..Default::default()
-        };
+        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR::default();
+        let mut capabilities = vk::VideoCapabilitiesKHR::default()
+            .push(&mut h264_capabilities)
+            .push(&mut encode_capabilities);
 
         // Query capabilities.
         let result = unsafe {
@@ -673,25 +641,19 @@ impl VideoContext {
         );
 
         // Create video profile info for H.265 encode with typical 8-bit 4:2:0.
-        let mut profile_info = vk::VideoProfileInfoKHR::default()
+        let profile_info = vk::VideoProfileInfoKHR::default()
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H265)
             .chroma_subsampling(vk::VideoChromaSubsamplingFlagsKHR::TYPE_420)
             .luma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8)
-            .chroma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8);
-
-        // Chain the codec-specific profile into profile_info.
-        profile_info.p_next = (&mut h265_profile as *mut vk::VideoEncodeH265ProfileInfoKHR).cast();
+            .chroma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8)
+            .push(&mut h265_profile);
 
         // Create capabilities structures.
         let mut h265_capabilities = vk::VideoEncodeH265CapabilitiesKHR::default();
-        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR {
-            p_next: &mut h265_capabilities as *mut vk::VideoEncodeH265CapabilitiesKHR as *mut _,
-            ..Default::default()
-        };
-        let mut capabilities = vk::VideoCapabilitiesKHR {
-            p_next: &mut encode_capabilities as *mut vk::VideoEncodeCapabilitiesKHR as *mut _,
-            ..Default::default()
-        };
+        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR::default();
+        let mut capabilities = vk::VideoCapabilitiesKHR::default()
+            .push(&mut h265_capabilities)
+            .push(&mut encode_capabilities);
 
         // Query capabilities.
         let result = unsafe {
@@ -737,25 +699,19 @@ impl VideoContext {
             .std_profile(ash::vk::native::StdVideoAV1Profile_STD_VIDEO_AV1_PROFILE_MAIN);
 
         // Create video profile info for AV1 encode with typical 8-bit 4:2:0.
-        let mut profile_info = vk::VideoProfileInfoKHR::default()
+        let profile_info = vk::VideoProfileInfoKHR::default()
             .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_AV1)
             .chroma_subsampling(vk::VideoChromaSubsamplingFlagsKHR::TYPE_420)
             .luma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8)
-            .chroma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8);
-
-        // Chain the codec-specific profile into profile_info.
-        profile_info.p_next = (&mut av1_profile as *mut vk::VideoEncodeAV1ProfileInfoKHR).cast();
+            .chroma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::TYPE_8)
+            .push(&mut av1_profile);
 
         // Create capabilities structures.
         let mut av1_capabilities = vk::VideoEncodeAV1CapabilitiesKHR::default();
-        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR {
-            p_next: &mut av1_capabilities as *mut vk::VideoEncodeAV1CapabilitiesKHR as *mut _,
-            ..Default::default()
-        };
-        let mut capabilities = vk::VideoCapabilitiesKHR {
-            p_next: &mut encode_capabilities as *mut vk::VideoEncodeCapabilitiesKHR as *mut _,
-            ..Default::default()
-        };
+        let mut encode_capabilities = vk::VideoEncodeCapabilitiesKHR::default();
+        let mut capabilities = vk::VideoCapabilitiesKHR::default()
+            .push(&mut av1_capabilities)
+            .push(&mut encode_capabilities);
 
         // Query capabilities.
         let result = unsafe {

--- a/src/vulkan.rs
+++ b/src/vulkan.rs
@@ -517,16 +517,18 @@ impl VideoContext {
             .enabled_extension_names(&extension_names)
             .push(&mut sync2_features);
 
+        if supported_encode_codecs.contains(&Codec::AV1) {
+            device_create_info = device_create_info.push(&mut av1_encode_features);
+        }
+
         // Attach the chain to device_create_info.
         // When descriptor buffer is available, the chain is:
         //   desc_buf_features -> buffer_device_address_features -> sync2_features -> ...
         // When descriptor buffer is not available, only sync2_features is chained.
         if has_descriptor_buffer_ext {
-            device_create_info = device_create_info.push(&mut desc_buf_features);
-            if supported_encode_codecs.contains(&Codec::AV1) {
-                device_create_info = device_create_info.push(&mut av1_encode_features);
-            }
             device_create_info = device_create_info
+                .push(&mut desc_buf_features)
+                .push(&mut buffer_device_address_features)
                 .push(&mut ycbcr_features)
                 .push(&mut ycbcr_2plane_444_features);
         }


### PR DESCRIPTION
### PR changes

Some cleaning and tidying up, with fixes and smaller changes along the way.


1. Switched from raw p_next assign to `ash` provided `push()` and few `extend()` methods.

2. Added AV1 codec query to `query_capabilities` example.

Doing the above also exposed few usage-issues:

- `query_capabilities` example was setting `VideoEncodeH264CapabilitiesKHR` as p_next on `VideoEncodeCapabilitiesKHR`, when it should be set on `VideoCapabilitiesKHR` as [per docs](https://docs.vulkan.org/refpages/latest/refpages/source/VkVideoEncodeH264CapabilitiesKHR.html#_c_specification), I repeated the fix for other codecs as well.

- `../av1/encode.rs` had `VideoEncodeAV1RateControlInfoKHR` being set as p_next on `VideoEncodeRateControlInfoKHR`, it should be on `VideoCodingControlInfoKHR` as [per docs](https://docs.vulkan.org/refpages/latest/refpages/source/VkVideoEncodeAV1RateControlInfoKHR.html#_description)

- In the same file as above, `VideoEncodeQualityLevelInfoKHR` was being set as p_next on `VideoCodingControlInfoKHR` when it should be on `VideoSessionParametersCreateInfoKHR` or `VideoCodingControlInfoKHR`, as [per docs](https://docs.vulkan.org/refpages/latest/refpages/source/VkVideoEncodeQualityLevelInfoKHR.html#_description).

- More similar cases which we're resolved and fixed as I went.


### Proposed future changes

- Rust edition is set to `2021` while latest has been `2024` for a good long while, LLMs tend to be biased towards older information as there's more of that available during training, always double check the work of LLMs, especially for outdated parts! Didn't make the change in this PR as it can potentially cause larger PR with `unsafe` changes that `2024` edition brought.


### Comment

Will start the PR as a draft, I've ran tests + query example on Radeon RX 9060 XT, RTX 2060 (+ Intel Arc A310, except it doesn't support Vulkan Video API, but it fails succesfully atleast).

Below are outputs of `cargo test` and `cargo run --example query_capabilities` on both supported GPUs.

[tests_radeon_nvidia.txt](https://github.com/user-attachments/files/28729565/tests_radeon_nvidia.txt)

Feel free to suggest changes, give feedback and whatnot, I've yet to test in "real scenario" but as it's already reaching 3am, I'll put out this draft so it doesn't get lost anywhere :slightly_smiling_face: 