### PR TITLE
fix: use limited range in SDR

### DIFF
--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -171,7 +171,7 @@ pub struct ColorConverterConfig {
 }
 
 impl ColorConverterConfig {
-    /// Create a new configuration with BT.709 color space and full range.
+    /// Create a new configuration with BT.709 color space and limited range.
     pub fn new(
         width: u32,
         height: u32,
@@ -184,7 +184,7 @@ impl ColorConverterConfig {
             input_format,
             output_format,
             color_space: ColorSpace::Bt709,
-            full_range: true,
+            full_range: false,
             sdr_reference_white_nits: 203.0,
         }
     }

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -244,13 +244,13 @@ pub struct ColorDescription {
 }
 
 impl ColorDescription {
-    /// BT.709 color description (standard SDR).
+    /// BT.709 color description (standard SDR, limited range).
     pub fn bt709() -> Self {
         Self {
             color_primaries: 1,
             transfer_characteristics: 1,
             matrix_coefficients: 1,
-            full_range: true,
+            full_range: false,
         }
     }
 
@@ -993,7 +993,7 @@ mod tests {
             assert_eq!(cd.color_primaries, 1);
             assert_eq!(cd.transfer_characteristics, 1);
             assert_eq!(cd.matrix_coefficients, 1);
-            assert!(cd.full_range);
+            assert!(!cd.full_range);
         }
 
         #[test]


### PR DESCRIPTION
Thanks to https://github.com/hgaiser/moonshine/pull/123

Also, PSNR values went from (`main`) :

```
  PASS: PSNR = 61.57 dB
  PASS: PSNR = 58.82 dB
  PASS: PSNR = 62.29 dB
  PASS: PSNR = 63.95 dB
  PASS: PSNR = 53.34 dB
  PASS: PSNR = 55.93 dB
  PASS: PSNR = 59.51 dB
  PASS: PSNR = 53.25 dB
```

To:

```
  PASS: PSNR = 61.57 dB
  PASS: PSNR = 58.82 dB
  PASS: PSNR = 62.29 dB
  PASS: PSNR = 63.95 dB
  PASS: PSNR = 59.87 dB
  PASS: PSNR = 61.23 dB
  PASS: PSNR = 59.51 dB
  PASS: PSNR = 59.65 dB
```

The only two that changed (and improved!) were for H265 encoding.