### PR TITLE
fix: queue family acquire on first DMA-BUF import

### DIFF
--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -584,11 +584,24 @@ impl ColorConverter {
 
             // --- Phase 1: Transition source image for shader read ---
 
+            // For external memory (DMA-BUF) imports with EXCLUSIVE sharing,
+            // the first use must include a queue family acquire operation.
+            // Set srcQueueFamilyIndex to EXTERNAL (ownership is foreign)
+            // and dstQueueFamilyIndex to the encoder's compute queue family.
+            let needs_acquire = src_layout == vk::ImageLayout::UNDEFINED;
             let src_barrier = vk::ImageMemoryBarrier::default()
                 .old_layout(src_layout)
                 .new_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
-                .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
-                .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .src_queue_family_index(if needs_acquire {
+                    vk::QUEUE_FAMILY_EXTERNAL
+                } else {
+                    vk::QUEUE_FAMILY_IGNORED
+                })
+                .dst_queue_family_index(if needs_acquire {
+                    self.context.compute_queue_family()
+                } else {
+                    vk::QUEUE_FAMILY_IGNORED
+                })
                 .image(src_image)
                 .subresource_range(vk::ImageSubresourceRange {
                     aspect_mask: vk::ImageAspectFlags::COLOR,
@@ -597,7 +610,11 @@ impl ColorConverter {
                     base_array_layer: 0,
                     layer_count: 1,
                 })
-                .src_access_mask(vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE)
+                .src_access_mask(if needs_acquire {
+                    vk::AccessFlags::empty()
+                } else {
+                    vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE
+                })
                 .dst_access_mask(vk::AccessFlags::SHADER_READ);
 
             device.cmd_pipeline_barrier(


### PR DESCRIPTION
Related to: https://github.com/hgaiser/moonshine/issues/93
Attemps to get rid of Black-Screen-Flickering when the Mouse appears/disappears.

Adheres closer to Vulkan Spec, forcing an acquire operation on first use by setting the family index of the source to external and recomputing the family index for the destination.
Similar idea for the access mask.