### PR TITLE
Make I-frame max QP and encode quality level configurable

### DIFF
--- a/src/encoder/av1/record.rs
+++ b/src/encoder/av1/record.rs
@@ -358,8 +358,8 @@ impl Av1 {
         }
 
         if is_first_frame {
-            let mut quality_level_info =
-                vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
+            let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default()
+                .quality_level(common.config.encode_quality_level);
             let control_info = vk::VideoCodingControlInfoKHR::default()
                 .flags(
                     vk::VideoCodingControlFlagsKHR::RESET

--- a/src/encoder/av1/session_params.rs
+++ b/src/encoder/av1/session_params.rs
@@ -151,7 +151,8 @@ impl Av1 {
                 .std_decoder_model_info(&decoder_model_info)
                 .std_operating_points(std::slice::from_ref(&operating_point));
 
-        let mut quality_info = vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
+        let mut quality_info = vk::VideoEncodeQualityLevelInfoKHR::default()
+            .quality_level(common.config.encode_quality_level);
         let session_params_create_info = vk::VideoSessionParametersCreateInfoKHR::default()
             .video_session(common.session)
             .push(&mut quality_info)

--- a/src/encoder/h264/record.rs
+++ b/src/encoder/h264/record.rs
@@ -431,13 +431,21 @@ impl H264 {
         // Rate control.
         let qp_bounds = if rc.is_disabled() { rc.qp as i32 } else { 18 };
         let qp_bounds_max = if rc.is_disabled() { rc.qp as i32 } else { 42 };
+        let qp_bounds_max_i = if rc.is_disabled() {
+            rc.qp as i32
+        } else {
+            common
+                .config
+                .max_qp_i
+                .map_or(qp_bounds_max, |qp| (qp as i32).max(qp_bounds))
+        };
         let min_qp = vk::VideoEncodeH264QpKHR {
             qp_i: qp_bounds,
             qp_p: qp_bounds,
             qp_b: qp_bounds,
         };
         let max_qp = vk::VideoEncodeH264QpKHR {
-            qp_i: qp_bounds_max,
+            qp_i: qp_bounds_max_i,
             qp_p: qp_bounds_max,
             qp_b: qp_bounds_max,
         };
@@ -496,8 +504,8 @@ impl H264 {
         // RESET + RATE_CONTROL + QUALITY_LEVEL in one control command on the first
         // frame (matches FFmpeg; required for AMD RADV).
         if is_first_frame {
-            let mut quality_level_info =
-                vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
+            let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default()
+                .quality_level(common.config.encode_quality_level);
             let control_info = vk::VideoCodingControlInfoKHR::default()
                 .flags(
                     vk::VideoCodingControlFlagsKHR::RESET

--- a/src/encoder/h264/session_params.rs
+++ b/src/encoder/h264/session_params.rs
@@ -174,7 +174,8 @@ impl H264 {
                 .parameters_add_info(&h264_add_info);
 
         // Chain quality level info (required by AMD RADV; matches FFmpeg).
-        let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
+        let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default()
+            .quality_level(config.encode_quality_level);
 
         let params_create_info = vk::VideoSessionParametersCreateInfoKHR::default()
             .video_session(common.session)

--- a/src/encoder/h265/record.rs
+++ b/src/encoder/h265/record.rs
@@ -406,13 +406,21 @@ impl H265 {
         // Rate control.
         let qp_min = if rc.is_disabled() { rc.qp as i32 } else { 26 };
         let qp_max = if rc.is_disabled() { rc.qp as i32 } else { 51 };
+        let qp_max_i = if rc.is_disabled() {
+            rc.qp as i32
+        } else {
+            common
+                .config
+                .max_qp_i
+                .map_or(qp_max, |qp| (qp as i32).max(qp_min))
+        };
         let min_qp = vk::VideoEncodeH265QpKHR {
             qp_i: qp_min,
             qp_p: qp_min,
             qp_b: qp_min,
         };
         let max_qp = vk::VideoEncodeH265QpKHR {
-            qp_i: qp_max,
+            qp_i: qp_max_i,
             qp_p: qp_max,
             qp_b: qp_max,
         };
@@ -466,8 +474,8 @@ impl H265 {
         }
 
         if is_first_frame {
-            let mut quality_level_info =
-                vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
+            let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default()
+                .quality_level(common.config.encode_quality_level);
             let control_info = vk::VideoCodingControlInfoKHR::default()
                 .flags(
                     vk::VideoCodingControlFlagsKHR::RESET

--- a/src/encoder/h265/session_params.rs
+++ b/src/encoder/h265/session_params.rs
@@ -333,7 +333,8 @@ impl H265 {
                 .max_std_pps_count(1)
                 .parameters_add_info(&h265_add_info);
 
-        let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default().quality_level(0);
+        let mut quality_level_info = vk::VideoEncodeQualityLevelInfoKHR::default()
+            .quality_level(common.config.encode_quality_level);
 
         let params_create_info = vk::VideoSessionParametersCreateInfoKHR::default()
             .video_session(common.session)

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -329,6 +329,18 @@ pub struct EncodeConfig {
     /// P-frames. Setting it equal to `virtual_buffer_size_ms` gives
     /// IDR frames maximum headroom.
     pub initial_virtual_buffer_size_ms: u32,
+    /// Maximum QP for I/IDR frames in rate-controlled modes.
+    /// `None` uses the codec default (42 for H.264, 51 for H.265).
+    /// Capping it below the default forces keyframes to spend enough bits
+    /// even before rate control has adapted to the content, at the cost of
+    /// larger keyframes. Values below the codec's minimum QP bound are
+    /// raised to it. Ignored by AV1 and by CQP/disabled rate control.
+    pub max_qp_i: Option<u32>,
+    /// Vulkan video encode quality level
+    /// (`VkVideoEncodeQualityLevelInfoKHR`). Higher levels trade encoding
+    /// speed for quality. Must be below the device's `maxQualityLevels`
+    /// for the video profile.
+    pub encode_quality_level: u32,
     /// Color description for VUI signaling.
     /// Defaults to BT.709 (full-range) when `None`.
     pub color_description: Option<ColorDescription>,
@@ -362,6 +374,8 @@ impl EncodeConfig {
             max_reference_frames: DEFAULT_MAX_REFERENCE_FRAMES,
             virtual_buffer_size_ms: 1000,
             initial_virtual_buffer_size_ms: 1000,
+            max_qp_i: None,
+            encode_quality_level: 0,
             color_description: None,
             encode_usage_hint: EncodeUsageHint::Default,
             encode_content_hint: EncodeContentHint::Default,
@@ -390,6 +404,8 @@ impl EncodeConfig {
             max_reference_frames: DEFAULT_MAX_REFERENCE_FRAMES,
             virtual_buffer_size_ms: 1000,
             initial_virtual_buffer_size_ms: 1000,
+            max_qp_i: None,
+            encode_quality_level: 0,
             color_description: None,
             encode_usage_hint: EncodeUsageHint::Default,
             encode_content_hint: EncodeContentHint::Default,
@@ -418,6 +434,8 @@ impl EncodeConfig {
             max_reference_frames: DEFAULT_MAX_REFERENCE_FRAMES,
             virtual_buffer_size_ms: 1000,
             initial_virtual_buffer_size_ms: 1000,
+            max_qp_i: None,
+            encode_quality_level: 0,
             color_description: None,
             encode_usage_hint: EncodeUsageHint::Default,
             encode_content_hint: EncodeContentHint::Default,
@@ -498,6 +516,18 @@ impl EncodeConfig {
     /// Use 0 to tightly constrain IDR/I-frame sizes.
     pub fn with_initial_virtual_buffer_size_ms(mut self, ms: u32) -> Self {
         self.initial_virtual_buffer_size_ms = ms;
+        self
+    }
+
+    /// Set the maximum QP for I/IDR frames in rate-controlled modes.
+    pub fn with_max_qp_i(mut self, qp: u32) -> Self {
+        self.max_qp_i = Some(qp);
+        self
+    }
+
+    /// Set the Vulkan video encode quality level.
+    pub fn with_encode_quality_level(mut self, level: u32) -> Self {
+        self.encode_quality_level = level;
         self
     }
 


### PR DESCRIPTION
EncodeConfig grows two knobs, both defaulting to the previous hardcoded behavior:

- `max_qp_i` caps the QP of I/IDR frames in rate-controlled modes (H.264/H.265; the codec defaults of 42/51 apply when unset, values below the codec's min bound are raised to it, AV1 and CQP/disabled are unaffected).
- `encode_quality_level` sets the Vulkan video encode quality level, previously hardcoded to 0. It is applied consistently to session parameters creation and the first-frame RESET/RATE_CONTROL/QUALITY_LEVEL control command in all three codecs, since the spec requires the bound session parameters to match the session's effective quality level.

Motivation: on a cold encoder the driver's rate control opens the stream with a conservative QP estimate. On static content the skip-coded P-frames then carry that first coarse keyframe until the next IDR, which shows up as gradient banding for the whole first GOP. Bounding `qp_i` forces the first keyframe to spend enough bits regardless of the initial estimate; verified on NVIDIA (RTX 3080 dev, L40S production) with `max_qp_i: 28` under VBR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)